### PR TITLE
Change `AutofacServiceFactory`: more `new`

### DIFF
--- a/src/Autofac.Extensions.DependencyInjection/AutofacRegistration.cs
+++ b/src/Autofac.Extensions.DependencyInjection/AutofacRegistration.cs
@@ -126,7 +126,7 @@ namespace Autofac.Extensions.DependencyInjection
                 {
                     var registration = RegistrationBuilder.ForDelegate(descriptor.ServiceType, (context, parameters) =>
                     {
-                        var serviceProvider = context.Resolve<IServiceProvider>();
+                        var serviceProvider = new AutofacServiceProvider(context);
                         return descriptor.ImplementationFactory(serviceProvider);
                     })
                     .ConfigureLifecycle(descriptor.Lifetime)

--- a/src/Autofac.Extensions.DependencyInjection/AutofacServiceProvider.cs
+++ b/src/Autofac.Extensions.DependencyInjection/AutofacServiceProvider.cs
@@ -66,6 +66,8 @@ namespace Autofac.Extensions.DependencyInjection
         /// </exception>
         public object GetRequiredService(Type serviceType)
         {
+            if (serviceType == typeof(IServiceProvider)) return this;
+            else if (serviceType == typeof(IServiceScopeFactory)) return new AutofacServiceScopeFactory((ILifetimeScope)_componentContext);
             return this._componentContext.Resolve(serviceType);
         }
 
@@ -81,6 +83,8 @@ namespace Autofac.Extensions.DependencyInjection
         /// </returns>
         public object GetService(Type serviceType)
         {
+            if (serviceType == typeof(IServiceProvider)) return this;
+            else if (serviceType == typeof(IServiceScopeFactory)) return new AutofacServiceScopeFactory((ILifetimeScope)_componentContext);
             return this._componentContext.ResolveOptional(serviceType);
         }
     }

--- a/src/Autofac.Extensions.DependencyInjection/AutofacServiceScope.cs
+++ b/src/Autofac.Extensions.DependencyInjection/AutofacServiceScope.cs
@@ -45,7 +45,7 @@ namespace Autofac.Extensions.DependencyInjection
         public AutofacServiceScope(ILifetimeScope lifetimeScope)
         {
             this._lifetimeScope = lifetimeScope;
-            this.ServiceProvider = this._lifetimeScope.Resolve<IServiceProvider>();
+            this.ServiceProvider = new AutofacServiceProvider(this._lifetimeScope);
         }
 
         /// <summary>

--- a/test/Autofac.Extensions.DependencyInjection.Test/SpecificationTests.cs
+++ b/test/Autofac.Extensions.DependencyInjection.Test/SpecificationTests.cs
@@ -13,7 +13,7 @@ namespace Autofac.Extensions.DependencyInjection.Test
             builder.Populate(serviceCollection);
 
             IContainer container = builder.Build();
-            return container.Resolve<IServiceProvider>();
+            return new AutofacServiceProvider(container);
         }
     }
 }


### PR DESCRIPTION
Submitted more as a commentary/reference to PR #10, this is a sketch of a more "consistent" version that replaces the function of `AutofacServiceFactory` outright.

Changes service-factory to return self if `IServiceFactory` is requested, and `new`-up a scope-factory when requested, rather than resolve.  Also, don't resolve `IServiceFactory` in other contexts where `new` will suffice.