### PR TITLE
Support for nested lifetime scopes

### DIFF
--- a/src/Autofac.Extensions.DependencyInjection/AutofacRegistration.cs
+++ b/src/Autofac.Extensions.DependencyInjection/AutofacRegistration.cs
@@ -56,7 +56,7 @@ namespace Autofac.Extensions.DependencyInjection
         public static void Populate(
             this ContainerBuilder builder,
             IEnumerable<ServiceDescriptor> descriptors,
-            string lifetimeScopeTagForSingletons = null)
+            object lifetimeScopeTagForSingletons = null)
         {
             builder.RegisterType<AutofacServiceProvider>().As<IServiceProvider>();
             builder.RegisterType<AutofacServiceScopeFactory>().As<IServiceScopeFactory>();

--- a/src/Autofac.Extensions.DependencyInjection/AutofacRegistration.cs
+++ b/src/Autofac.Extensions.DependencyInjection/AutofacRegistration.cs
@@ -47,8 +47,26 @@ namespace Autofac.Extensions.DependencyInjection
         /// <param name="descriptors">
         /// The set of service descriptors to register in the container.
         /// </param>
+        public static void Populate(
+            this ContainerBuilder builder,
+            IEnumerable<ServiceDescriptor> descriptors)
+        {
+            Populate(builder, descriptors, null);
+        }
+
+        /// <summary>
+        /// Populates the Autofac container builder with the set of registered service descriptors
+        /// and makes <see cref="IServiceProvider"/> and <see cref="IServiceScopeFactory"/>
+        /// available in the container.
+        /// </summary>
+        /// <param name="builder">
+        /// The <see cref="ContainerBuilder"/> into which the registrations should be made.
+        /// </param>
+        /// <param name="descriptors">
+        /// The set of service descriptors to register in the container.
+        /// </param>
         /// <param name="lifetimeScopeTagForSingletons">
-        /// If provided and not <c>null</c>then all registrations with lifetime <see cref="ServiceLifetime.Singleton" /> are registered
+        /// If provided and not <see langword="null"/> then all registrations with lifetime <see cref="ServiceLifetime.Singleton" /> are registered
         /// using <see cref="IRegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.InstancePerMatchingLifetimeScope" />
         /// with provided <paramref name="lifetimeScopeTagForSingletons"/>
         /// instead of using <see cref="IRegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.SingleInstance"/>.
@@ -56,7 +74,7 @@ namespace Autofac.Extensions.DependencyInjection
         public static void Populate(
             this ContainerBuilder builder,
             IEnumerable<ServiceDescriptor> descriptors,
-            object lifetimeScopeTagForSingletons = null)
+            object lifetimeScopeTagForSingletons)
         {
             builder.RegisterType<AutofacServiceProvider>().As<IServiceProvider>();
             builder.RegisterType<AutofacServiceScopeFactory>().As<IServiceScopeFactory>();
@@ -72,7 +90,7 @@ namespace Autofac.Extensions.DependencyInjection
         /// <param name="registrationBuilder">The registration being built.</param>
         /// <param name="lifecycleKind">The lifecycle specified on the service registration.</param>
         /// <param name="lifetimeScopeTagForSingleton">
-        /// If not <c>null</c> then all registrations with lifetime <see cref="ServiceLifetime.Singleton" /> are registered
+        /// If not <see langword="null"/> then all registrations with lifetime <see cref="ServiceLifetime.Singleton" /> are registered
         /// using <see cref="IRegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.InstancePerMatchingLifetimeScope" />
         /// with provided <paramref name="lifetimeScopeTagForSingleton"/>
         /// instead of using <see cref="IRegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.SingleInstance"/>.
@@ -120,7 +138,7 @@ namespace Autofac.Extensions.DependencyInjection
         /// The set of service descriptors to register in the container.
         /// </param>
         /// <param name="lifetimeScopeTagForSingletons">
-        /// If not <c>null</c> then all registrations with lifetime <see cref="ServiceLifetime.Singleton" /> are registered
+        /// If not <see langword="null"/> then all registrations with lifetime <see cref="ServiceLifetime.Singleton" /> are registered
         /// using <see cref="IRegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.InstancePerMatchingLifetimeScope" />
         /// with provided <paramref name="lifetimeScopeTagForSingletons"/>
         /// instead of using <see cref="IRegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.SingleInstance"/>.

--- a/test/Autofac.Extensions.DependencyInjection.Test/AutofacRegistrationTests.cs
+++ b/test/Autofac.Extensions.DependencyInjection.Test/AutofacRegistrationTests.cs
@@ -78,6 +78,19 @@ namespace Autofac.Extensions.DependencyInjection.Test
         }
 
         [Fact]
+        public void CanRebaseSingletonServiceToNamedLifetimeScope()
+        {
+            var builder = new ContainerBuilder();
+            var descriptor = new ServiceDescriptor(typeof(IService), typeof(Service), ServiceLifetime.Singleton);
+            builder.Populate(new ServiceDescriptor[] { descriptor }, "MY_SCOPE");
+            var container = builder.Build();
+
+            container.AssertLifetime<IService, MatchingScopeLifetime>();
+            container.AssertSharing<IService>(InstanceSharing.Shared);
+            container.AssertOwnership<IService>(InstanceOwnership.OwnedByLifetimeScope);
+        }
+
+        [Fact]
         public void CanRegisterScopedService()
         {
             var builder = new ContainerBuilder();


### PR DESCRIPTION
If an application has a lifetime scope already and is required to start a web server then we have to register the dependencies with the root lifetime scope otherwise we run into some resolving issues (see comment https://github.com/autofac/Autofac/issues/659#issuecomment-155135678).

The proposed workaround in https://github.com/autofac/Autofac/issues/659#issuecomment-155135678 comes with (at least) 2 problems:
* We don't want to mess with the root lifetime scope because other parts of the application, besides the web server, don't need ASP.NET Core components
* ContainerBuilder.Update is deprecated (https://github.com/autofac/Autofac/issues/811)

Fix for: https://github.com/autofac/Autofac/issues/659

The fix of the problem with nested lifetime scope lies in "rebasing" the singletons to a specific lifetime scope (that is considered to be the root of the web server) instead of registering this components with the real root lifetime scope.

Usage:
```
public class Startup
{
	private const string _WEBSERVER_SCOPE_NAME = "ASPNET_WEBSERVER_ROOT";

        // is provided from outside of "Startup"
	private readonly ILifetimeScope _scope;

	...

	public IServiceProvider ConfigureServices(IServiceCollection services)
	{
		// add ASP.NET Core components
		services.AddMvc();
		...

		// create a named scope that should be the root scope used by the ASP.NET Core pipeline
		var aspnetScope = _scope.BeginLifetimeScope(_WEBSERVER_SCOPE_NAME, 
				builder => builder.Populate(services, _WEBSERVER_SCOPE_NAME));

		return new AutofacServiceProvider(aspnetScope);
	}
}
```