### PR TITLE
Added an overload of AddAutofac that takes a ContainerBuilder in para…

### DIFF
--- a/src/Autofac.Extensions.DependencyInjection/AutofacServiceProviderFactory.cs
+++ b/src/Autofac.Extensions.DependencyInjection/AutofacServiceProviderFactory.cs
@@ -33,6 +33,7 @@ namespace Autofac.Extensions.DependencyInjection
     /// </summary>
     public class AutofacServiceProviderFactory : IServiceProviderFactory<ContainerBuilder>
     {
+        private readonly ContainerBuilder _containerBuilder;
         private readonly Action<ContainerBuilder> _configurationAction;
 
         /// <summary>
@@ -42,6 +43,17 @@ namespace Autofac.Extensions.DependencyInjection
         public AutofacServiceProviderFactory(Action<ContainerBuilder> configurationAction = null)
         {
             _configurationAction = configurationAction ?? (builder => { });
+            _containerBuilder = new ContainerBuilder();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AutofacServiceProviderFactory"/> class.
+        /// </summary>
+        /// <param name="containerBuilder">The <see cref="ContainerBuilder"/> to use.</param>
+        public AutofacServiceProviderFactory(ContainerBuilder containerBuilder)
+        {
+            _containerBuilder = containerBuilder ?? throw new ArgumentNullException(nameof(containerBuilder));
+            _configurationAction = builder => { };
         }
 
         /// <summary>
@@ -51,13 +63,10 @@ namespace Autofac.Extensions.DependencyInjection
         /// <returns>A container builder that can be used to create an <see cref="T:System.IServiceProvider" />.</returns>
         public ContainerBuilder CreateBuilder(IServiceCollection services)
         {
-            var builder = new ContainerBuilder();
+            _containerBuilder.Populate(services);
+            _configurationAction(_containerBuilder);
 
-            builder.Populate(services);
-
-            _configurationAction(builder);
-
-            return builder;
+            return _containerBuilder;
         }
 
         /// <summary>

--- a/src/Autofac.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Autofac.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -43,5 +43,18 @@ namespace Autofac.Extensions.DependencyInjection
         {
             return services.AddSingleton<IServiceProviderFactory<ContainerBuilder>>(new AutofacServiceProviderFactory(configurationAction));
         }
+
+        /// <summary>
+        /// Adds the <see cref="AutofacServiceProviderFactory"/> to the service collection.
+        /// </summary>
+        /// <param name="services">The service collection to add the factory to.</param>
+        /// <param name="containerBuilder">The <see cref="ContainerBuilder"/> to be used in the ServiceProviderFactory.</param>
+        /// <returns>The service collection.</returns>
+        public static IServiceCollection AddAutofac(this IServiceCollection services, ContainerBuilder containerBuilder)
+        {
+            if (containerBuilder == null) throw new ArgumentNullException(nameof(containerBuilder));
+
+            return services.AddSingleton<IServiceProviderFactory<ContainerBuilder>>(new AutofacServiceProviderFactory(containerBuilder));
+        }
     }
 }

--- a/test/Autofac.Extensions.DependencyInjection.Test/AutofacServiceProviderFactoryTests.cs
+++ b/test/Autofac.Extensions.DependencyInjection.Test/AutofacServiceProviderFactoryTests.cs
@@ -7,6 +7,12 @@ namespace Autofac.Extensions.DependencyInjection.Test
     public class AutofacServiceProviderFactoryTests
     {
         [Fact]
+        public void CtorThrowsWhenNullContainerBuilder()
+        {
+            Assert.Throws<ArgumentNullException>(() => new AutofacServiceProviderFactory((ContainerBuilder)null));
+        }
+
+        [Fact]
         public void CreateBuilderReturnsNewInstance()
         {
             var factory = new AutofacServiceProviderFactory();
@@ -78,6 +84,19 @@ namespace Autofac.Extensions.DependencyInjection.Test
             var serviceProvider = factory.CreateServiceProvider(new ContainerBuilder());
 
             Assert.IsType<AutofacServiceProvider>(serviceProvider);
+        }
+
+        [Fact]
+        public void CreateBuilderReturnsSameContainerBuilderAsTheOneProvidedInCtor()
+        {
+            var originalBuilder = new ContainerBuilder();
+            originalBuilder.Register(c => "Foo");
+            var factory = new AutofacServiceProviderFactory(originalBuilder);
+
+            var builder = factory.CreateBuilder(new ServiceCollection());
+
+            Assert.Same(originalBuilder, builder);
+            Assert.Equal("Foo", builder.Build().Resolve<string>());
         }
     }
 }

--- a/test/Autofac.Extensions.DependencyInjection.Test/ServiceCollectionExtensionsTests.cs
+++ b/test/Autofac.Extensions.DependencyInjection.Test/ServiceCollectionExtensionsTests.cs
@@ -40,5 +40,21 @@ namespace Autofac.Extensions.DependencyInjection.Test
             var builder = factory.CreateBuilder(collection);
             Assert.Equal("Foo", builder.Build().Resolve<string>());
         }
+
+        [Fact]
+        public void AddAutofacWithContainerBuilderWillReturnSameBuilderAndRegisterServices()
+        {
+            var originalBuilder = new ContainerBuilder();
+            originalBuilder.Register(c => "Foo");
+
+            var collection = new ServiceCollection();
+            collection.AddAutofac(originalBuilder);
+
+            var serviceProvider = collection.BuildServiceProvider();
+            var factory = (IServiceProviderFactory<ContainerBuilder>)serviceProvider.GetService(typeof(IServiceProviderFactory<ContainerBuilder>));
+            var builder = factory.CreateBuilder(collection);
+            Assert.Same(originalBuilder, builder);
+            Assert.Equal("Foo", builder.Build().Resolve<string>());
+        }
     }
 }


### PR DESCRIPTION
…meter

I find this to be useful for testing purposes, when coupled with the use of ```TestServer```.

I was unfortunately unable to run the tests with Visual Studio 2017 as I can't seem to compile, I have multiple compilation errors due to NetStandard version and the analyzers packages.

Just let me know if this is something that you would consider merging or not ;-)

In the same vein, I think it would be nice to have an ```AddAutofac``` extension method on the ```IWebHostBuilder``` interface, a bit like in [StructureMap](https://github.com/structuremap/StructureMap.Microsoft.DependencyInjection/blob/master/src/StructureMap.AspNetCore/WebHostBuilderExtensions.cs).