### PR TITLE
Update autofac to latest stable fixes #32

### DIFF
--- a/src/Autofac.Extensions.DependencyInjection/Autofac.Extensions.DependencyInjection.csproj
+++ b/src/Autofac.Extensions.DependencyInjection/Autofac.Extensions.DependencyInjection.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.2.0" />
+    <PackageReference Include="Autofac" Version="4.8.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/test/Autofac.Extensions.DependencyInjection.Test/Autofac.Extensions.DependencyInjection.Test.csproj
+++ b/test/Autofac.Extensions.DependencyInjection.Test/Autofac.Extensions.DependencyInjection.Test.csproj
@@ -24,7 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Autofac" Version="4.2.0" />
+    <PackageReference Include="Autofac" Version="4.8.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="2.1.1" />

--- a/test/Autofac.Extensions.DependencyInjection.Test/AutofacRegistrationTests.cs
+++ b/test/Autofac.Extensions.DependencyInjection.Test/AutofacRegistrationTests.cs
@@ -156,6 +156,31 @@ namespace Autofac.Extensions.DependencyInjection.Test
         }
 
         [Fact]
+        public void CanResolveTOptionsFromChildContainer()
+        {
+            ServiceCollection services = new ServiceCollection();
+
+            ContainerBuilder builder = new ContainerBuilder();
+            builder.Populate(services);
+
+            IContainer rootContainer = builder.Build();
+            ILifetimeScope childContainer = rootContainer.BeginLifetimeScope((a) =>
+            {
+                ServiceCollection childServices = new ServiceCollection();
+                childServices.AddOptions();
+                childServices.Configure<TestOptions>((b) =>
+                {
+                    b.Value = 6;
+                });
+                a.Populate(childServices);
+            });
+
+            AutofacServiceProvider childSp = new AutofacServiceProvider(childContainer);
+            IOptions<TestOptions> options = childSp.GetRequiredService<IOptions<TestOptions>>();
+            Assert.Equal(6, options.Value?.Value);
+        }
+
+        [Fact]
         public void RegistrationsAddedAfterPopulateComeLastWhenResolvedWithIEnumerable()
         {
             const string s1 = "s1";

--- a/test/Autofac.Extensions.DependencyInjection.Test/AutofacRegistrationTests.cs
+++ b/test/Autofac.Extensions.DependencyInjection.Test/AutofacRegistrationTests.cs
@@ -158,10 +158,7 @@ namespace Autofac.Extensions.DependencyInjection.Test
         [Fact]
         public void CanResolveTOptionsFromChildContainer()
         {
-            ServiceCollection services = new ServiceCollection();
-
             ContainerBuilder builder = new ContainerBuilder();
-            builder.Populate(services);
 
             IContainer rootContainer = builder.Build();
             ILifetimeScope childContainer = rootContainer.BeginLifetimeScope((a) =>


### PR DESCRIPTION
Added a failing test case to repro an issue where you can't seem to register and use `IOptions<T>` at a child lifetime scope level. They work fine when registered and resolved from root level only.