### PR TITLE
Update Autofac reference to 4.9.1

### DIFF
--- a/src/Autofac.Extensions.DependencyInjection/Autofac.Extensions.DependencyInjection.csproj
+++ b/src/Autofac.Extensions.DependencyInjection/Autofac.Extensions.DependencyInjection.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.6.1" />
+    <PackageReference Include="Autofac" Version="4.9.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
- Today the Autofac referenced by Autofac.Extensions.DependencyInjection is pre-netstandard 2.0. This changes makes it so that
it won't pull in an insane amount of dependencies.


PS: It's ok to not take this change. I just wanted to start the discussion.