### PR TITLE
Update dependencies

### DIFF
--- a/src/Autofac.Extensions.DependencyInjection/Autofac.Extensions.DependencyInjection.csproj
+++ b/src/Autofac.Extensions.DependencyInjection/Autofac.Extensions.DependencyInjection.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.6.1" />
+    <PackageReference Include="Autofac" Version="4.9.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -42,7 +42,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.1.0" Condition="$(TargetFramework) == 'netstandard1.1'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0" Condition="$(TargetFramework) == 'netstandard2.0'" />
     <PackageReference Include="Microsoft.Net.RoslynDiagnostics" Version="2.6.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Autofac.Extensions.DependencyInjection/Autofac.Extensions.DependencyInjection.csproj
+++ b/src/Autofac.Extensions.DependencyInjection/Autofac.Extensions.DependencyInjection.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Autofac implementation of the interfaces in Microsoft.Extensions.DependencyInjection.Abstractions, the .NET Framework dependency injection abstraction.</Description>
-    <VersionPrefix>4.3.1</VersionPrefix>
+    <VersionPrefix>4.4.0</VersionPrefix>
     <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/test/Autofac.Extensions.DependencyInjection.Test/Autofac.Extensions.DependencyInjection.Test.csproj
+++ b/test/Autofac.Extensions.DependencyInjection.Test/Autofac.Extensions.DependencyInjection.Test.csproj
@@ -24,7 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Autofac" Version="4.6.1" />
+    <PackageReference Include="Autofac" Version="4.9.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="2.1.1" />


### PR DESCRIPTION
- Update to **Autofac** 4.9.1 and **Microsoft.Extensions.DependencyInjection.Abstractions** 2.1.0 to netstandard 2.0 dependencies. This reduces the dependency closure when installing this package on netstandard 2.0 compatible platforms. 

This is what happens today when you install it in an ASP.NET Core project:

![image](https://user-images.githubusercontent.com/95136/53289985-d90f1100-3752-11e9-8646-2628366f10d4.png)

After these changes:

![image](https://user-images.githubusercontent.com/95136/53290268-41132680-3756-11e9-9242-2c9944820e92.png)
