### PR TITLE
Add child-scope service-provider factory allowing users to keep their root-scope free of modifications

### DIFF
--- a/src/Autofac.Extensions.DependencyInjection/AutofacChildScopeConfigurationAdapter.cs
+++ b/src/Autofac.Extensions.DependencyInjection/AutofacChildScopeConfigurationAdapter.cs
@@ -1,0 +1,55 @@
+﻿// This software is part of the Autofac IoC container
+// Copyright © 2019 Autofac Contributors
+// https://autofac.org
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+
+namespace Autofac.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Configuration adapter for <see cref="AutofacChildScopeServiceProviderFactory" />.
+    /// </summary>
+    public class AutofacChildScopeConfigurationAdapter
+    {
+        private readonly List<Action<ContainerBuilder>> _childScopeConfigurationActions = new List<Action<ContainerBuilder>>();
+
+        /// <summary>
+        /// Adds a configuration-actions to the list of actions that shall be executed when the scope is created.
+        /// </summary>
+        /// <param name="configurationAction">Action on a <see cref="ContainerBuilder"/> that adds component registrations to the container.</param>
+        /// <exception cref="ArgumentNullException">Throws when the passed configuration-action is null.</exception>
+        public void Add(Action<ContainerBuilder> configurationAction)
+        {
+            if (configurationAction == null) throw new ArgumentNullException(nameof(configurationAction));
+
+            _childScopeConfigurationActions.Add(configurationAction);
+        }
+
+        /// <summary>
+        /// Gets the list of configurationActions to be executed on the <see cref="ContainerBuilder"/>.
+        /// </summary>
+        public IReadOnlyList<Action<ContainerBuilder>> ChildScopeConfigurationActions => _childScopeConfigurationActions;
+    }
+}

--- a/src/Autofac.Extensions.DependencyInjection/AutofacChildScopeServiceProviderFactory.cs
+++ b/src/Autofac.Extensions.DependencyInjection/AutofacChildScopeServiceProviderFactory.cs
@@ -1,0 +1,99 @@
+﻿// This software is part of the Autofac IoC container
+// Copyright © 2019 Autofac Contributors
+// https://autofac.org
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Autofac.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// A factory for creating a child-scope based on a root-scope using <see cref="ILifetimeScope"/> and producing an <see cref="IServiceProvider" />.
+    /// </summary>
+    public class AutofacChildScopeServiceProviderFactory : IServiceProviderFactory<AutofacChildScopeConfigurationAdapter>
+    {
+        private readonly Action<ContainerBuilder> _containerConfigurationAction;
+        private readonly ILifetimeScope _rootLifetimeScope;
+        private static readonly Action<ContainerBuilder> FallbackConfigurationAction = builder => { };
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AutofacChildScopeServiceProviderFactory"/> class.
+        /// </summary>
+        /// <param name="getRootLifetimeScopeFunc">Function to retrieve the root-container instance built using <see cref="ContainerBuilder"/>.</param>
+        /// <param name="configurationAction">Action on a <see cref="ContainerBuilder"/> that adds component registrations to the container.</param>
+        public AutofacChildScopeServiceProviderFactory(Func<ILifetimeScope> getRootLifetimeScopeFunc, Action<ContainerBuilder> configurationAction = null)
+        {
+            if (getRootLifetimeScopeFunc == null) throw new ArgumentNullException(nameof(getRootLifetimeScopeFunc));
+
+            _rootLifetimeScope = getRootLifetimeScopeFunc();
+            _containerConfigurationAction = configurationAction ?? AutofacChildScopeServiceProviderFactory.FallbackConfigurationAction;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AutofacChildScopeServiceProviderFactory"/> class.
+        /// </summary>
+        /// <param name="rootLifetimeScope">The root-container instance built using <see cref="ContainerBuilder"/>.</param>
+        /// <param name="configurationAction">Action on a <see cref="ContainerBuilder"/> that adds component registrations to the container.</param>
+        public AutofacChildScopeServiceProviderFactory(ILifetimeScope rootLifetimeScope, Action<ContainerBuilder> configurationAction = null)
+        {
+            _rootLifetimeScope = rootLifetimeScope ?? throw new ArgumentNullException(nameof(rootLifetimeScope));
+            _containerConfigurationAction = configurationAction ?? AutofacChildScopeServiceProviderFactory.FallbackConfigurationAction;
+        }
+
+        /// <summary>
+        /// Creates a container builder from an <see cref="IServiceCollection" />.
+        /// </summary>
+        /// <param name="services">The collection of services.</param>
+        /// <returns>A container builder that can be used to create an <see cref="IServiceProvider" />.</returns>
+        public AutofacChildScopeConfigurationAdapter CreateBuilder(IServiceCollection services)
+        {
+            var actions = new AutofacChildScopeConfigurationAdapter();
+
+            actions.Add(builder => builder.Populate(services));
+            actions.Add(builder => _containerConfigurationAction(builder));
+
+            return actions;
+        }
+
+        /// <summary>
+        /// Creates an <see cref="IServiceProvider" /> from the container builder.
+        /// </summary>
+        /// <param name="autofacChildScopeConfigurationAdapter">The adapter holding configuration applied to <see cref="ContainerBuilder"/> creating the <see cref="IServiceProvider"/>.</param>
+        /// <returns>An <see cref="IServiceProvider" />.</returns>
+        public IServiceProvider CreateServiceProvider(AutofacChildScopeConfigurationAdapter autofacChildScopeConfigurationAdapter)
+        {
+            if (autofacChildScopeConfigurationAdapter == null) throw new ArgumentNullException(nameof(autofacChildScopeConfigurationAdapter));
+
+            var scope = _rootLifetimeScope.BeginLifetimeScope(scopeBuilder =>
+            {
+                foreach (var action in autofacChildScopeConfigurationAdapter.ChildScopeConfigurationActions)
+                {
+                    action(scopeBuilder);
+                }
+            });
+
+            return new AutofacServiceProvider(scope);
+        }
+    }
+}

--- a/src/Autofac.Extensions.DependencyInjection/HostBuilderExtensions.cs
+++ b/src/Autofac.Extensions.DependencyInjection/HostBuilderExtensions.cs
@@ -41,5 +41,27 @@ namespace Autofac.Extensions.DependencyInjection
         /// <param name="configurationAction">Action on a <see cref="ContainerBuilder"/> that adds component registrations to the container.</param>
         public static IHostBuilder UseAutofac(this IHostBuilder hostBuilder, Action<ContainerBuilder> configurationAction = null) =>
             hostBuilder.UseServiceProviderFactory(new AutofacServiceProviderFactory(configurationAction));
+
+        /// <summary>
+        /// Register the <see cref="AutofacChildScopeServiceProviderFactory" /> with the Host.
+        /// </summary>
+        /// <param name="hostBuilder">The instance of the <see cref="IHostBuilder"/>.</param>
+        /// <param name="getRootLifetimeScopeFunc">Function to retrieve the root-container instance built using <see cref="ContainerBuilder"/>.</param>
+        /// <param name="configurationAction">Action on a <see cref="ContainerBuilder"/> that adds component registrations to the container.</param>
+        /// <returns>The instance of the <see cref="IHostBuilder"/>.</returns>
+        public static IHostBuilder UseAutofacChildScopeFactory(this IHostBuilder hostBuilder, Func<ILifetimeScope> getRootLifetimeScopeFunc, Action<ContainerBuilder> configurationAction = null) =>
+            hostBuilder.UseServiceProviderFactory(
+                new AutofacChildScopeServiceProviderFactory(getRootLifetimeScopeFunc, configurationAction));
+
+        /// <summary>
+        /// Register the <see cref="AutofacChildScopeServiceProviderFactory" /> with the Host.
+        /// </summary>
+        /// <param name="hostBuilder">The instance of the <see cref="IHostBuilder"/>.</param>
+        /// <param name="rootLifetimeScope">The root-container instance built using <see cref="ContainerBuilder"/>.</param>
+        /// <param name="configurationAction">Action on a <see cref="ContainerBuilder"/> that adds component registrations to the container.</param>
+        /// <returns>The instance of the <see cref="IHostBuilder"/>.</returns>
+        public static IHostBuilder UseAutofacChildScopeFactory(this IHostBuilder hostBuilder, ILifetimeScope rootLifetimeScope, Action<ContainerBuilder> configurationAction = null) =>
+            hostBuilder.UseServiceProviderFactory(
+                new AutofacChildScopeServiceProviderFactory(rootLifetimeScope, configurationAction));
     }
 }

--- a/src/Autofac.Extensions.DependencyInjection/Properties/AssemblyInfo.cs
+++ b/src/Autofac.Extensions.DependencyInjection/Properties/AssemblyInfo.cs
@@ -23,7 +23,6 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-using System;
 using System.Reflection;
 using System.Resources;
 using System.Runtime.CompilerServices;

--- a/test/Autofac.Extensions.DependencyInjection.Test/AutofacChildScopeConfigurationAdapterTests.cs
+++ b/test/Autofac.Extensions.DependencyInjection.Test/AutofacChildScopeConfigurationAdapterTests.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Xunit;
+
+namespace Autofac.Extensions.DependencyInjection.Test
+{
+    public sealed class AutofacChildScopeConfigurationAdapterTests
+    {
+        [Fact]
+        public void AddMultipleConfigurationContainsConfigurations()
+        {
+            var autofacChildScopeConfigurationAdapter = new AutofacChildScopeConfigurationAdapter();
+            autofacChildScopeConfigurationAdapter.Add(builder => { });
+            autofacChildScopeConfigurationAdapter.Add(builder => { });
+
+            Assert.Equal(2, autofacChildScopeConfigurationAdapter.ChildScopeConfigurationActions.Count);
+        }
+
+        [Fact]
+        public void AddNullConfigurationThrows()
+            => Assert.Throws<ArgumentNullException>(() => new AutofacChildScopeConfigurationAdapter().Add(null));
+    }
+}

--- a/test/Autofac.Extensions.DependencyInjection.Test/AutofacChildScopeServiceProviderFactoryTests.cs
+++ b/test/Autofac.Extensions.DependencyInjection.Test/AutofacChildScopeServiceProviderFactoryTests.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Autofac.Extensions.DependencyInjection.Test
+{
+    public sealed class AutofacChildScopeServiceProviderFactoryTests
+    {
+        [Fact]
+        public void CreateBuilderReturnsNewInstance()
+        {
+            var factory = new AutofacChildScopeServiceProviderFactory(GetRootLifetimeScope);
+
+            var autofacChildScopeConfigurationAdapter = factory.CreateBuilder(new ServiceCollection());
+
+            Assert.NotNull(autofacChildScopeConfigurationAdapter);
+        }
+
+        [Fact]
+        public void CreateBuilderExecutesConfigurationActionWhenProvided()
+        {
+            var factory = new AutofacChildScopeServiceProviderFactory(GetRootLifetimeScope, builder => builder.Register(c => "Foo"));
+
+            var autofacChildScopeConfigurationAdapter = factory.CreateBuilder(new ServiceCollection());
+
+            var builder = new ContainerBuilder();
+
+            foreach (var action in autofacChildScopeConfigurationAdapter.ChildScopeConfigurationActions)
+            {
+                action(builder);
+            }
+
+            Assert.Equal("Foo", builder.Build().Resolve<string>());
+        }
+
+        [Fact]
+        public void CreateBuilderAllowsForNullConfigurationAction()
+        {
+            var factory = new AutofacChildScopeServiceProviderFactory(GetRootLifetimeScope);
+
+            var autofacChildScopeConfigurationAdapter = factory.CreateBuilder(new ServiceCollection());
+
+            Assert.NotNull(autofacChildScopeConfigurationAdapter);
+        }
+
+        [Fact]
+        public void CreateBuilderReturnsInstanceWithServicesPopulated()
+        {
+            var factory = new AutofacChildScopeServiceProviderFactory(GetRootLifetimeScope);
+            var services = new ServiceCollection().AddTransient<object>();
+
+            var autofacChildScopeConfigurationAdapter = factory.CreateBuilder(services);
+
+            var builder = new ContainerBuilder();
+
+            foreach (var action in autofacChildScopeConfigurationAdapter.ChildScopeConfigurationActions)
+            {
+                action(builder);
+            }
+
+            Assert.True(builder.Build().IsRegistered<object>());
+        }
+
+        [Fact]
+        public void CreateServiceProviderBuildsServiceProviderUsingAdapter()
+        {
+            var factory = new AutofacChildScopeServiceProviderFactory(GetRootLifetimeScope);
+            var services = new ServiceCollection().AddTransient<object>();
+            var autofacChildScopeConfigurationAdapter = factory.CreateBuilder(services);
+
+            var serviceProvider = factory.CreateServiceProvider(autofacChildScopeConfigurationAdapter);
+
+            Assert.NotNull(serviceProvider.GetService(typeof(object)));
+        }
+
+        [Fact]
+        public void CreateServiceProviderThrowsWhenProvidedNullAdapter()
+        {
+            var factory = new AutofacChildScopeServiceProviderFactory(GetRootLifetimeScope);
+
+            var exception = Assert.Throws<ArgumentNullException>(() => factory.CreateServiceProvider(null));
+
+            Assert.Equal("autofacChildScopeConfigurationAdapter", exception.ParamName);
+        }
+
+        [Fact]
+        public void CreateServiceProviderReturnsAutofacServiceProvider()
+        {
+            var factory = new AutofacChildScopeServiceProviderFactory(GetRootLifetimeScope);
+
+            var serviceProvider = factory.CreateServiceProvider(new AutofacChildScopeConfigurationAdapter());
+
+            Assert.IsType<AutofacServiceProvider>(serviceProvider);
+        }
+
+        [Fact]
+        public void CreateServiceProviderAddDepToServiceCollectionAndAddConfigurationTypesResolveable()
+        {
+            var factory = new AutofacChildScopeServiceProviderFactory(GetRootLifetimeScope);
+
+            var services = new ServiceCollection().AddTransient<DependencyOne>();
+
+            var autofacChildScopeConfigurationAdapter = factory.CreateBuilder(services);
+
+            autofacChildScopeConfigurationAdapter.Add(builder => builder.RegisterType<DependencyTwo>());
+
+            var serviceProvider = factory.CreateServiceProvider(autofacChildScopeConfigurationAdapter);
+
+            serviceProvider.GetRequiredService<DependencyOne>();
+            serviceProvider.GetRequiredService<DependencyTwo>();
+        }
+
+        [Fact]
+        public void CreateServiceProviderAddDepToRootContainerResolveable()
+        {
+            var factory = new AutofacChildScopeServiceProviderFactory(GetRootLifetimescopeWithDependency<DependencyOne>(typeof(DependencyOne)));
+
+            var autofacChildScopeConfigurationAdapter = factory.CreateBuilder(new ServiceCollection());
+
+            var serviceProvider = factory.CreateServiceProvider(autofacChildScopeConfigurationAdapter);
+
+            serviceProvider.GetRequiredService<DependencyOne>();
+        }
+
+        private static ILifetimeScope GetRootLifetimeScope() => new ContainerBuilder().Build();
+
+        private static ILifetimeScope GetRootLifetimescopeWithDependency<TAs>(Type type)
+        {
+            var containerBuilder = new ContainerBuilder();
+
+            containerBuilder
+                .RegisterType(type)
+                .As<TAs>();
+
+            return containerBuilder.Build();
+        }
+
+        private class DependencyOne
+        {
+        }
+
+        private class DependencyTwo
+        {
+        }
+    }
+}

--- a/test/Autofac.Extensions.DependencyInjection.Test/HostBuilderExtensionsTests.cs
+++ b/test/Autofac.Extensions.DependencyInjection.Test/HostBuilderExtensionsTests.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
+﻿using Microsoft.Extensions.Hosting;
 using Xunit;
 
 namespace Autofac.Extensions.DependencyInjection.Test
@@ -15,5 +14,29 @@ namespace Autofac.Extensions.DependencyInjection.Test
 
             Assert.IsAssignableFrom<AutofacServiceProvider>(host.Services);
         }
+
+        [Fact]
+        public void UseAutofacChildScopeFactoryWithDelegateAutofacServiceProviderResolveable()
+        {
+            var host = Host.CreateDefaultBuilder(null)
+                .UseAutofacChildScopeFactory(GetRootLifetimeScope)
+                .Build();
+
+            Assert.IsAssignableFrom<AutofacServiceProvider>(host.Services);
+        }
+
+        [Fact]
+        public void UseAutofacChildScopeFactoryWithInstanceAutofacServiceProviderResolveable()
+        {
+            var rootLifetimeScope = GetRootLifetimeScope();
+
+            var host = Host.CreateDefaultBuilder(null)
+                .UseAutofacChildScopeFactory(rootLifetimeScope)
+                .Build();
+
+            Assert.IsAssignableFrom<AutofacServiceProvider>(host.Services);
+        }
+
+        private static ILifetimeScope GetRootLifetimeScope() => new ContainerBuilder().Build();
     }
 }


### PR DESCRIPTION
This PR contains changes that allows users to keep a root-lifetime scope that won't be modified to include services from `Microsoft.Extensions.DependencyInjection.ServiceCollection` when using `Autofac` with `Host`.

**FYI:** This PR contains changes of #51. I will rebase this branch based on it until it has been merged. Important changes for this PR:

* Add class `AutofacChildScopeServiceProviderFactory` and `AutofacChildScopeConfigurationAdapter`
* Add extension methods to `HostBuilderExtensions` that allows registering the child-scope factory
* Add tests
