### PR TITLE
Set Advanced Build Settings / Output / Debugging information to "Full…

### DIFF
--- a/src/Autofac.Extensions.DependencyInjection/Autofac.Extensions.DependencyInjection.csproj
+++ b/src/Autofac.Extensions.DependencyInjection/Autofac.Extensions.DependencyInjection.csproj
@@ -32,6 +32,16 @@
     <Product>Autofac</Product>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.4">


### PR DESCRIPTION
For issue 58: https://github.com/autofac/Autofac.Extensions.DependencyInjection/issues/58

Resolve issue with "Indexed source information could not be retrieved from..." on certain TFS servers."

From commit:
…" (has the effect of modying .csproj file to add <DebugType>full</DebugType> for each debug and release configurations.