### PR TITLE
Added IAsyncDisposable support to the IServiceScope and IServiceProvider

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <clear/>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="Xunit MyGet" value="https://myget.org/F/xunit/api/v3/index.json" protocolVersion="3" />
+    <clear />
+    <add key="Autofac MyGet" value="https://www.myget.org/F/autofac/api/v2" />
+    <add key="NuGet v3" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <add key="Microsoft and .NET" value="true" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 5.0.1.{build}
+version: 6.0.0.{build}
 
 configuration: Release
 

--- a/src/Autofac.Extensions.DependencyInjection/Autofac.Extensions.DependencyInjection.csproj
+++ b/src/Autofac.Extensions.DependencyInjection/Autofac.Extensions.DependencyInjection.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Autofac implementation of the interfaces in Microsoft.Extensions.DependencyInjection.Abstractions, the .NET Framework dependency injection abstraction.</Description>
     <VersionPrefix>5.0.1</VersionPrefix>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Autofac.Extensions.DependencyInjection</AssemblyName>
@@ -32,8 +32,12 @@
     <Product>Autofac</Product>
   </PropertyGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0-preview1.19504.10" />
+  </ItemGroup>
+
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.9.1" />
+    <PackageReference Include="Autofac" Version="5.0.0-develop-00622" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Autofac.Extensions.DependencyInjection/AutofacServiceScope.cs
+++ b/src/Autofac.Extensions.DependencyInjection/AutofacServiceScope.cs
@@ -24,6 +24,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Autofac.Extensions.DependencyInjection
@@ -32,7 +33,7 @@ namespace Autofac.Extensions.DependencyInjection
     /// Autofac implementation of the ASP.NET Core <see cref="IServiceScope"/>.
     /// </summary>
     /// <seealso cref="Microsoft.Extensions.DependencyInjection.IServiceScope" />
-    internal class AutofacServiceScope : IServiceScope
+    internal class AutofacServiceScope : IServiceScope, IAsyncDisposable
     {
         private bool _disposed;
         private readonly AutofacServiceProvider _serviceProvider;
@@ -81,12 +82,21 @@ namespace Autofac.Extensions.DependencyInjection
         {
             if (!this._disposed)
             {
+                this._disposed = true;
+
                 if (disposing)
                 {
                     this._serviceProvider.Dispose();
                 }
+            }
+        }
 
+        public async ValueTask DisposeAsync()
+        {
+            if (!this._disposed)
+            {
                 this._disposed = true;
+                await this._serviceProvider.DisposeAsync();
             }
         }
     }

--- a/test/Autofac.Extensions.DependencyInjection.Test/Autofac.Extensions.DependencyInjection.Test.csproj
+++ b/test/Autofac.Extensions.DependencyInjection.Test/Autofac.Extensions.DependencyInjection.Test.csproj
@@ -24,7 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Autofac" Version="4.9.1" />
+    <PackageReference Include="Autofac" Version="5.0.0-develop-00622" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Following on from the Autofac Core async disposal support in https://github.com/autofac/Autofac/pull/1037, these changes add the necessary support to the DependencyInjection integration. 

Added netstandard2.1 targeting with the conditional async interfaces package for netstandard2.0.

With these changes, any services inside a per-request lifetime scope that implement IAsyncDisposable get DisposeAsync called at the end of the request, instead of Dispose.

I believe this change requires a major version bump (to 6.0.0), because we're now depending on the next major release of Autofac.