### PR TITLE
Add benchmarks for requests through default DI (baseline) and autofac.

### DIFF
--- a/Autofac.Extensions.DependencyInjection.sln
+++ b/Autofac.Extensions.DependencyInjection.sln
@@ -9,15 +9,23 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{DEA4A8C6-D
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6B324E70-6C86-4E09-B150-CAE9DD2BADCC}"
 	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
 		appveyor.yml = appveyor.yml
 		global.json = global.json
 		NuGet.Config = NuGet.Config
-		.gitignore = .gitignore
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Autofac.Extensions.DependencyInjection", "src\Autofac.Extensions.DependencyInjection\Autofac.Extensions.DependencyInjection.csproj", "{513C7F7A-A758-4D48-94F4-891A00F63DA1}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Autofac.Extensions.DependencyInjection.Test", "test\Autofac.Extensions.DependencyInjection.Test\Autofac.Extensions.DependencyInjection.Test.csproj", "{911AA52A-4E68-41C5-AB24-D1618AFDF753}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "bench", "bench", "{C39BE99E-D778-485B-920A-42D4EB3CBA75}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Autofac.Extensions.DependencyInjection.Bench", "bench\Autofac.Extensions.DependencyInjection.Bench\Autofac.Extensions.DependencyInjection.Bench.csproj", "{639CD744-1E61-4EF8-9E5A-9920A6BC3891}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "projects", "projects", "{7D26E232-3D30-4151-BB0A-C5965419F268}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BenchProject.AutofacApiServer", "bench\projects\Bench.AutofacApiServer\BenchProject.AutofacApiServer.csproj", "{F835591F-9578-411E-908F-BB46FD4DB00C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -63,6 +71,38 @@ Global
 		{911AA52A-4E68-41C5-AB24-D1618AFDF753}.Release|x64.Build.0 = Release|Any CPU
 		{911AA52A-4E68-41C5-AB24-D1618AFDF753}.Release|x86.ActiveCfg = Release|Any CPU
 		{911AA52A-4E68-41C5-AB24-D1618AFDF753}.Release|x86.Build.0 = Release|Any CPU
+		{639CD744-1E61-4EF8-9E5A-9920A6BC3891}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{639CD744-1E61-4EF8-9E5A-9920A6BC3891}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{639CD744-1E61-4EF8-9E5A-9920A6BC3891}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{639CD744-1E61-4EF8-9E5A-9920A6BC3891}.Debug|ARM.Build.0 = Debug|Any CPU
+		{639CD744-1E61-4EF8-9E5A-9920A6BC3891}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{639CD744-1E61-4EF8-9E5A-9920A6BC3891}.Debug|x64.Build.0 = Debug|Any CPU
+		{639CD744-1E61-4EF8-9E5A-9920A6BC3891}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{639CD744-1E61-4EF8-9E5A-9920A6BC3891}.Debug|x86.Build.0 = Debug|Any CPU
+		{639CD744-1E61-4EF8-9E5A-9920A6BC3891}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{639CD744-1E61-4EF8-9E5A-9920A6BC3891}.Release|Any CPU.Build.0 = Release|Any CPU
+		{639CD744-1E61-4EF8-9E5A-9920A6BC3891}.Release|ARM.ActiveCfg = Release|Any CPU
+		{639CD744-1E61-4EF8-9E5A-9920A6BC3891}.Release|ARM.Build.0 = Release|Any CPU
+		{639CD744-1E61-4EF8-9E5A-9920A6BC3891}.Release|x64.ActiveCfg = Release|Any CPU
+		{639CD744-1E61-4EF8-9E5A-9920A6BC3891}.Release|x64.Build.0 = Release|Any CPU
+		{639CD744-1E61-4EF8-9E5A-9920A6BC3891}.Release|x86.ActiveCfg = Release|Any CPU
+		{639CD744-1E61-4EF8-9E5A-9920A6BC3891}.Release|x86.Build.0 = Release|Any CPU
+		{F835591F-9578-411E-908F-BB46FD4DB00C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F835591F-9578-411E-908F-BB46FD4DB00C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F835591F-9578-411E-908F-BB46FD4DB00C}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{F835591F-9578-411E-908F-BB46FD4DB00C}.Debug|ARM.Build.0 = Debug|Any CPU
+		{F835591F-9578-411E-908F-BB46FD4DB00C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F835591F-9578-411E-908F-BB46FD4DB00C}.Debug|x64.Build.0 = Debug|Any CPU
+		{F835591F-9578-411E-908F-BB46FD4DB00C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F835591F-9578-411E-908F-BB46FD4DB00C}.Debug|x86.Build.0 = Debug|Any CPU
+		{F835591F-9578-411E-908F-BB46FD4DB00C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F835591F-9578-411E-908F-BB46FD4DB00C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F835591F-9578-411E-908F-BB46FD4DB00C}.Release|ARM.ActiveCfg = Release|Any CPU
+		{F835591F-9578-411E-908F-BB46FD4DB00C}.Release|ARM.Build.0 = Release|Any CPU
+		{F835591F-9578-411E-908F-BB46FD4DB00C}.Release|x64.ActiveCfg = Release|Any CPU
+		{F835591F-9578-411E-908F-BB46FD4DB00C}.Release|x64.Build.0 = Release|Any CPU
+		{F835591F-9578-411E-908F-BB46FD4DB00C}.Release|x86.ActiveCfg = Release|Any CPU
+		{F835591F-9578-411E-908F-BB46FD4DB00C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -70,9 +110,12 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{513C7F7A-A758-4D48-94F4-891A00F63DA1} = {5A54DF18-E3F3-4929-876D-00650A15763E}
 		{911AA52A-4E68-41C5-AB24-D1618AFDF753} = {DEA4A8C6-DE56-4359-A87C-472FB34132E7}
+		{639CD744-1E61-4EF8-9E5A-9920A6BC3891} = {C39BE99E-D778-485B-920A-42D4EB3CBA75}
+		{7D26E232-3D30-4151-BB0A-C5965419F268} = {C39BE99E-D778-485B-920A-42D4EB3CBA75}
+		{F835591F-9578-411E-908F-BB46FD4DB00C} = {7D26E232-3D30-4151-BB0A-C5965419F268}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		EnterpriseLibraryConfigurationToolBinariesPath = packages\Unity.2.1.505.0\lib\NET35;packages\Unity.Interception.2.1.505.0\lib\NET35;packages\EnterpriseLibrary.Common.5.0.505.0\lib\NET35;packages\EnterpriseLibrary.ExceptionHandling.5.0.505.0\lib\NET35;packages\Unity.2.1.505.2\lib\NET35;packages\Unity.Interception.2.1.505.2\lib\NET35
 		SolutionGuid = {76E0A652-E5E2-4CA4-BAFD-AF6FDE0BD56A}
+		EnterpriseLibraryConfigurationToolBinariesPath = packages\Unity.2.1.505.0\lib\NET35;packages\Unity.Interception.2.1.505.0\lib\NET35;packages\EnterpriseLibrary.Common.5.0.505.0\lib\NET35;packages\EnterpriseLibrary.ExceptionHandling.5.0.505.0\lib\NET35;packages\Unity.2.1.505.2\lib\NET35;packages\Unity.Interception.2.1.505.2\lib\NET35
 	EndGlobalSection
 EndGlobal

--- a/bench/Autofac.Extensions.DependencyInjection.Bench/Autofac.Extensions.DependencyInjection.Bench.csproj
+++ b/bench/Autofac.Extensions.DependencyInjection.Bench/Autofac.Extensions.DependencyInjection.Bench.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Autofac.Extensions.DependencyInjection\Autofac.Extensions.DependencyInjection.csproj" />
+    <ProjectReference Include="..\projects\Bench.AutofacApiServer\BenchProject.AutofacApiServer.csproj" />
+  </ItemGroup>
+  
+</Project>

--- a/bench/Autofac.Extensions.DependencyInjection.Bench/AutofacWebApplicationFactory.cs
+++ b/bench/Autofac.Extensions.DependencyInjection.Bench/AutofacWebApplicationFactory.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Hosting;
+
+namespace Autofac.Extensions.DependencyInjection.Bench
+{
+    public class AutofacWebApplicationFactory<TStartup> : WebApplicationFactory<TStartup>
+        where TStartup : class
+    {
+        protected override IHost CreateHost(IHostBuilder builder)
+        {
+            builder.UseServiceProviderFactory(new AutofacServiceProviderFactory());
+
+            return base.CreateHost(builder);
+        }
+    }
+}

--- a/bench/Autofac.Extensions.DependencyInjection.Bench/BenchmarkConfig.cs
+++ b/bench/Autofac.Extensions.DependencyInjection.Bench/BenchmarkConfig.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Jobs;
+
+namespace Autofac.Extensions.DependencyInjection.Bench
+{
+    internal class BenchmarkConfig : ManualConfig
+    {
+        internal BenchmarkConfig()
+        {
+            Add(DefaultConfig.Instance);
+
+            var rootFolder = AppContext.BaseDirectory.Substring(0, AppContext.BaseDirectory.LastIndexOf("bin", StringComparison.OrdinalIgnoreCase));
+            var runFolder = DateTime.Now.ToString("u").Replace(' ', '_').Replace(':', '-');
+            ArtifactsPath = $"{rootFolder}\\BenchmarkDotNet.Artifacts\\{runFolder}";
+
+            AddDiagnoser(MemoryDiagnoser.Default);
+        }
+    }
+}

--- a/bench/Autofac.Extensions.DependencyInjection.Bench/BenchmarkConfig.cs
+++ b/bench/Autofac.Extensions.DependencyInjection.Bench/BenchmarkConfig.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Jobs;
@@ -11,9 +12,12 @@ namespace Autofac.Extensions.DependencyInjection.Bench
         {
             Add(DefaultConfig.Instance);
 
+            AddJob(Job.InProcess);
+
+
             var rootFolder = AppContext.BaseDirectory.Substring(0, AppContext.BaseDirectory.LastIndexOf("bin", StringComparison.OrdinalIgnoreCase));
             var runFolder = DateTime.Now.ToString("u").Replace(' ', '_').Replace(':', '-');
-            ArtifactsPath = $"{rootFolder}\\BenchmarkDotNet.Artifacts\\{runFolder}";
+            ArtifactsPath = Path.Join(rootFolder, "BenchmarkDotNet.Artifacts", runFolder);
 
             AddDiagnoser(MemoryDiagnoser.Default);
         }

--- a/bench/Autofac.Extensions.DependencyInjection.Bench/Benchmarks.cs
+++ b/bench/Autofac.Extensions.DependencyInjection.Bench/Benchmarks.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Autofac.Extensions.DependencyInjection.Bench
+{
+    public static class Benchmarks
+    {
+        public static Type[] All { get; } = new[]
+        {
+            typeof(RequestBenchmark)
+        };
+    }
+}

--- a/bench/Autofac.Extensions.DependencyInjection.Bench/Program.cs
+++ b/bench/Autofac.Extensions.DependencyInjection.Bench/Program.cs
@@ -1,0 +1,10 @@
+﻿using BenchmarkDotNet.Running;
+
+namespace Autofac.Extensions.DependencyInjection.Bench
+{
+    internal static class Program
+    {
+        internal static void Main(string[] args) =>
+            new BenchmarkSwitcher(Benchmarks.All).Run(args, new BenchmarkConfig());
+    }
+}

--- a/bench/Autofac.Extensions.DependencyInjection.Bench/RequestBenchmark.cs
+++ b/bench/Autofac.Extensions.DependencyInjection.Bench/RequestBenchmark.cs
@@ -1,0 +1,57 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchProject.AutofacApiServer;
+using Microsoft.AspNetCore.Mvc.Testing;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Autofac.Extensions.DependencyInjection.Bench
+{
+    public class RequestBenchmark
+    {
+        private WebApplicationFactory<DefaultStartup> _defaultFactory;
+        private WebApplicationFactory<DefaultStartup> _autofacFactory;
+        private HttpClient _defaultClient;
+        private HttpClient _autofacClient;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _defaultFactory = new WebApplicationFactory<DefaultStartup>();
+            _autofacFactory = new AutofacWebApplicationFactory<DefaultStartup>();
+
+            _defaultClient = _defaultFactory.CreateClient();
+            _autofacClient = _autofacFactory.CreateClient();
+        }
+
+        [Benchmark(Baseline = true)]
+        public async Task Request_DefaultDI()
+        {
+            var response = await _defaultClient.GetAsync("/api/values");
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                throw new HttpRequestException();
+            }
+        }
+
+        [Benchmark]
+        public async Task Request_AutofacDI()
+        {
+            var response = await _autofacClient.GetAsync("/api/values");
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                throw new HttpRequestException();
+            }
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            _defaultFactory.Dispose();
+            _autofacFactory.Dispose();
+        }
+    }
+}

--- a/bench/projects/Bench.AutofacApiServer/BenchProject.AutofacApiServer.csproj
+++ b/bench/projects/Bench.AutofacApiServer/BenchProject.AutofacApiServer.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+
+</Project>

--- a/bench/projects/Bench.AutofacApiServer/Controllers/ValuesController.cs
+++ b/bench/projects/Bench.AutofacApiServer/Controllers/ValuesController.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BenchProject.AutofacApiServer.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class ValuesController : ControllerBase
+    {
+        private readonly A service;
+
+        public ValuesController(A service)
+        {
+            this.service = service;
+        }
+
+        [HttpGet]
+        public IActionResult Get()
+        {
+            return Ok(200);
+        }
+    }
+}

--- a/bench/projects/Bench.AutofacApiServer/DefaultStartup.cs
+++ b/bench/projects/Bench.AutofacApiServer/DefaultStartup.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace BenchProject.AutofacApiServer
+{
+    public class DefaultStartup
+    {
+        public DefaultStartup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllers();
+
+            services.AddTransient<A>();
+            services.AddTransient<B1>();
+            services.AddTransient<B2>();
+            services.AddTransient<C1>();
+            services.AddTransient<C2>();
+            services.AddTransient<D1>();
+            services.AddTransient<D2>();
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
+        }
+    }
+}

--- a/bench/projects/Bench.AutofacApiServer/Program.cs
+++ b/bench/projects/Bench.AutofacApiServer/Program.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace BenchProject.AutofacApiServer
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            var host = CreateHostBuilder(args).Build();
+
+            host.Run();
+        }
+
+        private static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<DefaultStartup>();
+                });
+    }
+}

--- a/bench/projects/Bench.AutofacApiServer/Properties/launchSettings.json
+++ b/bench/projects/Bench.AutofacApiServer/Properties/launchSettings.json
@@ -1,0 +1,30 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:55009",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "weatherforecast",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "Bench.AutofacApiServer": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "weatherforecast",
+      "applicationUrl": "http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/bench/projects/Bench.AutofacApiServer/Services.cs
+++ b/bench/projects/Bench.AutofacApiServer/Services.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace BenchProject.AutofacApiServer
+{
+    public class A
+    {
+        public A(B1 b1, B2 b2) { }
+    }
+
+    public class B1
+    {
+        public B1(B2 b2, C1 c1, C2 c2) { }
+    }
+
+    public class B2
+    {
+        public B2(C1 c1, C2 c2) { }
+    }
+
+    public class C1
+    {
+        public C1(C2 c2, D1 d1, D2 d2) { }
+    }
+
+    public class C2
+    {
+        public C2(D1 d1, D2 d2) { }
+    }
+
+    public class D1 { }
+
+    public class D2 { }
+}

--- a/bench/projects/Bench.AutofacApiServer/appsettings.Development.json
+++ b/bench/projects/Bench.AutofacApiServer/appsettings.Development.json
@@ -1,9 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
-    }
-  }
-}

--- a/bench/projects/Bench.AutofacApiServer/appsettings.Development.json
+++ b/bench/projects/Bench.AutofacApiServer/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/bench/projects/Bench.AutofacApiServer/appsettings.json
+++ b/bench/projects/Bench.AutofacApiServer/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "3.0.100"
+    "version": "3.1.200",
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
I wanted to be able to benchmark the added overhead of Autofac in the DI extension as compared to built-in MS DI, so I added a benchmarks project. Want to see what material impact the v6 changes will have on the ASP.NET Core request time (if any).

I've used the ASP.NET Core MVC test package to spin up two in-memory versions of the same project (Default DI and Autofac), and run a benchmark.

Inside the test project, I've got the equivalent of the DeepGraph benchmark from the main Autofac benchmarks to give us a comparison.

Gives output like this:

|            Method |     Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------ |---------:|---------:|---------:|------:|--------:|-------:|------:|------:|----------:|
| Request_DefaultDI | 66.23 us | 0.592 us | 0.494 us |  1.00 |    0.00 | 3.6621 |     - |     - |  14.96 KB |
| Request_AutofacDI | 96.15 us | 1.057 us | 0.937 us |  1.45 |    0.02 | 8.6670 |     - |     - |  35.64 KB |

It would be good to add additional benchmarks for more complex cases (IEnumerable, Generics, Meta/Func/Owned, etc).