### PR TITLE
Changing global.json to actual .net6 release

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100-preview.5.21302.13",
+    "version": "6.0.100",
     "rollForward": "latestFeature"
   },
   "additionalSdks": [


### PR DESCRIPTION
I don't think anything else has to change...but we can now release a .net6 targeting build (not pre-release).