### PR TITLE
Ability to register modules per request in WebApi

### DIFF
--- a/src/Autofac.Extensions.DependencyInjection/IPerRequestModuleAccessor.cs
+++ b/src/Autofac.Extensions.DependencyInjection/IPerRequestModuleAccessor.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+using System.Collections.Generic;
+using Autofac.Core;
+
+namespace Autofac.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// An accessor to get a list of module registrations that will be registered for each
+    /// request.
+    /// </summary>
+    public interface IPerRequestModuleAccessor
+    {
+        /// <summary>
+        /// Gets a list of module registrations that will be registered for each request.
+        /// </summary>
+        IEnumerable<IModule> Modules { get; }
+    }
+}


### PR DESCRIPTION
Ability to register modules per request in WebApi
Similar to this feature in WCF: https://github.com/autofac/Autofac.Wcf/pull/19

I worked with @tillig on the feature for WCF.
I am finally moving my Api from WCF to WebApi and I'm trying to replicate the ability to register modules per web API request in .net core 6.

If this feature already exists elsewhere and I missed it, please let me know; but I couldn't find it.

During my investigation, AutofacServiecProvider seemed to be the best place to put this, and it works, in that my modules are registered per request. I'm submitting my working changes so we can start a discussion on if my changes are appropriate or not.

