### PR TITLE
Add SonarAnalyzer.CSharp and tighten Roslyn analyzer rules

### DIFF
--- a/bench/Autofac.Extensions.DependencyInjection.Bench/Autofac.Extensions.DependencyInjection.Bench.csproj
+++ b/bench/Autofac.Extensions.DependencyInjection.Bench/Autofac.Extensions.DependencyInjection.Bench.csproj
@@ -34,6 +34,10 @@
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/bench/Autofac.Extensions.DependencyInjection.Bench/Harness.cs
+++ b/bench/Autofac.Extensions.DependencyInjection.Bench/Harness.cs
@@ -8,10 +8,18 @@ namespace Autofac.Extensions.DependencyInjection.Bench;
 public class Harness
 {
     [Fact]
-    public void Request() => RunBenchmark<RequestBenchmark>();
+    public void Request()
+    {
+        var exception = Record.Exception(RunBenchmark<RequestBenchmark>);
+        Assert.Null(exception);
+    }
 
     [Fact]
-    public void KeyedResolution() => RunBenchmark<KeyedResolutionBenchmark>();
+    public void KeyedResolution()
+    {
+        var exception = Record.Exception(RunBenchmark<KeyedResolutionBenchmark>);
+        Assert.Null(exception);
+    }
 
     /// <remarks>
     /// This method is used to enforce that benchmark types are added to <see cref="Benchmarks.All"/>

--- a/bench/Autofac.Extensions.DependencyInjection.Bench/Program.cs
+++ b/bench/Autofac.Extensions.DependencyInjection.Bench/Program.cs
@@ -52,10 +52,17 @@ public sealed class Program
     {
         var forwarded = new List<string>(args.Length);
         string? baseline = null;
+        var expectingBaselineValue = false;
 
-        for (var i = 0; i < args.Length; i++)
+        foreach (var arg in args)
         {
-            var arg = args[i];
+            if (expectingBaselineValue)
+            {
+                baseline = arg;
+                expectingBaselineValue = false;
+                continue;
+            }
+
             if (TryMatchBaselineArg(arg, out var inlineVersion))
             {
                 if (!string.IsNullOrWhiteSpace(inlineVersion))
@@ -64,16 +71,16 @@ public sealed class Program
                     continue;
                 }
 
-                if (i + 1 >= args.Length)
-                {
-                    throw new ArgumentException("Missing version value for baseline argument.", nameof(args));
-                }
-
-                baseline = args[++i];
+                expectingBaselineValue = true;
                 continue;
             }
 
             forwarded.Add(arg);
+        }
+
+        if (expectingBaselineValue)
+        {
+            throw new ArgumentException("Missing version value for baseline argument.", nameof(args));
         }
 
         return (forwarded.ToArray(), baseline);

--- a/build/Source.ruleset
+++ b/build/Source.ruleset
@@ -42,6 +42,8 @@
     <!-- Loops should use LINQ - DI container hot paths intentionally avoid LINQ allocations. -->
     <Rule Id="S3267" Action="None" />
     <Rule Id="S3776" Action="Warning" />
+    <!-- Split method for params check + iterator - overly prescriptive for our patterns. -->
+    <Rule Id="S4456" Action="None" />
     <Rule Id="S6418" Action="Warning" />
     <Rule Id="S6444" Action="Warning" />
   </Rules>

--- a/build/Source.ruleset
+++ b/build/Source.ruleset
@@ -4,6 +4,8 @@
   <Rules AnalyzerId="Microsoft.CodeAnalysis.Analyzers" RuleNamespace="Microsoft.CodeAnalysis.Analyzers">
     <!-- Implement standard exception constructors - not all of the exception constructors are desired. -->
     <Rule Id="CA1032" Action="None" />
+    <!-- Implement IDisposable correctly (must be explicitly enabled). -->
+    <Rule Id="CA1063" Action="Warning" />
     <!-- Avoid excessive inheritance (must be explicitly enabled). -->
     <Rule Id="CA1501" Action="Warning" />
     <!-- Avoid excessive complexity (must be explicitly enabled). -->
@@ -44,6 +46,8 @@
     <!-- Loops should use LINQ - DI container hot paths intentionally avoid LINQ allocations. -->
     <Rule Id="S3267" Action="None" />
     <Rule Id="S3776" Action="Warning" />
+    <!-- IDisposable pattern - Autofac uses non-standard dispose patterns for container lifecycle. -->
+    <Rule Id="S3881" Action="None" />
     <!-- Split method for params check + iterator - overly prescriptive for our patterns. -->
     <Rule Id="S4456" Action="None" />
     <Rule Id="S6418" Action="Warning" />

--- a/build/Source.ruleset
+++ b/build/Source.ruleset
@@ -32,6 +32,8 @@
   <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
     <!-- "Sonar Way" rules to match SonarQube scans. -->
     <Rule Id="S107" Action="Warning" />
+    <!-- Do not use obsolete members - Autofac maintains deprecated APIs for backward compat. -->
+    <Rule Id="S1133" Action="None" />
     <Rule Id="S1192" Action="Warning" />
     <Rule Id="S1313" Action="Warning" />
     <Rule Id="S2259" Action="Warning" />

--- a/build/Source.ruleset
+++ b/build/Source.ruleset
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="16.0">
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac source assemblies." ToolsVersion="16.0">
   <IncludeAll Action="Warning" />
-  <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
-    <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.Analyzers" RuleNamespace="Microsoft.CodeAnalysis.Analyzers">
+    <!-- Implement standard exception constructors - not all of the exception constructors are desired. -->
     <Rule Id="CA1032" Action="None" />
     <!-- Avoid excessive inheritance (must be explicitly enabled). -->
     <Rule Id="CA1501" Action="Warning" />
@@ -12,20 +12,38 @@
     <Rule Id="CA1505" Action="Warning" />
     <!-- Avoid excessive class coupling (must be explicitly enabled). -->
     <Rule Id="CA1506" Action="Warning" />
-    <!-- Use ArgumentNullException.ThrowIfNull - this isn't available until we stop targeting netstandard. -->
+    <!-- Use ArgumentNullException.ThrowIfNull - not available in netstandard. -->
     <Rule Id="CA1510" Action="None" />
-    <!-- Use ArgumentOutOfRangeException.ThrowIfNegative - this isn't available until we stop targeting anything below net8.0. -->
+    <!-- Use ArgumentOutOfRangeException.ThrowIfNegative - not available below net8.0. -->
     <Rule Id="CA1512" Action="None" />
-    <!-- Use ObjectDisposedException.ThrowIf - this isn't available until we stop targeting anything below net8.0. -->
+    <!-- Use ObjectDisposedException.ThrowIf - not available below net8.0. -->
     <Rule Id="CA1513" Action="None" />
-    <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
+    <!-- Change names to avoid reserved word overlaps - would break public API. -->
     <Rule Id="CA1716" Action="None" />
-    <!-- Cache a CompositeFormat object for use in String.Format - this isn't available until we stop targeting netstandard, and we only String.Format when throwing exceptions so the work/complexity isn't justified to increase perf just for those situations. -->
+    <!-- Cache a CompositeFormat - not available in netstandard. -->
     <Rule Id="CA1863" Action="None" />
-    <!-- Implement serialization constructors - false positive when building .NET Core. -->
+    <!-- Implement serialization constructors - false positive in .NET Core. -->
     <Rule Id="CA2229" Action="None" />
-    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
+    <!-- Mark ISerializable types with SerializableAttribute - false positive in .NET Core. -->
     <Rule Id="CA2237" Action="None" />
+    <!-- Prefer generic overloads - conflicts with reflection work in Autofac. -->
+    <Rule Id="CA2263" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
+    <!-- "Sonar Way" rules to match SonarQube scans. -->
+    <Rule Id="S107" Action="Warning" />
+    <Rule Id="S1192" Action="Warning" />
+    <Rule Id="S1313" Action="Warning" />
+    <Rule Id="S2259" Action="Warning" />
+    <Rule Id="S2583" Action="Warning" />
+    <Rule Id="S2589" Action="Warning" />
+    <!-- Verify reflection accessibility bypass - DI containers do extensive reflection by design. -->
+    <Rule Id="S3011" Action="None" />
+    <!-- Loops should use LINQ - DI container hot paths intentionally avoid LINQ allocations. -->
+    <Rule Id="S3267" Action="None" />
+    <Rule Id="S3776" Action="Warning" />
+    <Rule Id="S6418" Action="Warning" />
+    <Rule Id="S6444" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <!-- Prefix local calls with this. -->

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -55,6 +55,8 @@
     <!-- Don't call GC.Collect - required for weak reference and disposal tests. -->
     <Rule Id="S1215" Action="None" />
     <!-- Remove unused private members - reflection tests need non-public members. -->
+    <!-- Do not use obsolete members - tests exercise deprecated APIs to verify backward compat. -->
+    <Rule Id="S1133" Action="None" />
     <Rule Id="S1144" Action="None" />
     <!-- Empty method bodies - test stubs often have no-op implementations. -->
     <Rule Id="S1186" Action="None" />

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -42,6 +42,8 @@
     <Rule Id="CA2234" Action="None" />
     <!-- Mark ISerializable types with SerializableAttribute - false positive in .NET Core. -->
     <Rule Id="CA2237" Action="None" />
+    <!-- Nested types should not be visible - test scenario classes use nested types extensively. -->
+    <Rule Id="CA1034" Action="None" />
     <!-- Prefer generic overloads - reflection work in Autofac needs to be tested. -->
     <Rule Id="CA2263" Action="None" />
   </Rules>

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -48,6 +48,10 @@
   <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
     <!-- Don't use hardcoded paths or URIs - needed in several test cases. -->
     <Rule Id="S1075" Action="None" />
+    <!-- Utility class should not be instantiated - test fixture classes with nested tests can't be static. -->
+    <Rule Id="S1118" Action="None" />
+    <!-- Don't call GC.Collect - required for weak reference and disposal tests. -->
+    <Rule Id="S1215" Action="None" />
     <!-- Remove unused private members - reflection tests need non-public members. -->
     <Rule Id="S1144" Action="None" />
     <!-- Empty method bodies - test stubs often have no-op implementations. -->
@@ -72,8 +76,18 @@
     <Rule Id="S2335" Action="None" />
     <!-- Cognitive complexity (must be explicitly enabled). -->
     <Rule Id="S3776" Action="Warning" />
+    <!-- Split method for params check + iterator - overly prescriptive for our patterns. -->
+    <Rule Id="S4456" Action="None" />
+    <!-- Don't use Thread.Sleep - required for concurrency and timing tests. -->
+    <Rule Id="S2925" Action="None" />
+    <!-- NSubstitute mock verification is complete without property access. -->
+    <Rule Id="S2970" Action="None" />
+    <!-- Fields only assigned in constructor - needed to prevent optimization in reflection tests. -->
+    <Rule Id="S4487" Action="None" />
     <!-- Set route attributes at top of controller - false positive. -->
     <Rule Id="S6934" Action="None" />
+    <!-- Use async dispose - sync dispose tests are intentional. -->
+    <Rule Id="S6966" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <!-- Prefix local calls with this. -->

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -23,6 +23,10 @@
     <!-- Remove underscores from member name - test naming conventions use underscore. -->
     <Rule Id="CA1707" Action="None" />
     <!-- Internal class that appears to never be instantiated - false positives from DI. -->
+    <!-- Identifiers should not have incorrect suffix - test classes use Impl, Handler, etc. -->
+    <Rule Id="CA1711" Action="None" />
+    <!-- Property names should not match get methods - aggregate service tests intentionally test both. -->
+    <Rule Id="CA1721" Action="None" />
     <Rule Id="CA1812" Action="None" />
     <!-- Change Dispose() to call GC.SuppressFinalize - unimportant in tests. -->
     <Rule Id="CA1816" Action="None" />
@@ -55,6 +59,8 @@
     <!-- Don't use hardcoded paths or URIs - needed in several test cases. -->
     <Rule Id="S1075" Action="None" />
     <!-- Utility class should not be instantiated - test fixture classes with nested tests can't be static. -->
+    <!-- Sections of code should not be commented out - test files may retain commented examples. -->
+    <Rule Id="S125" Action="None" />
     <Rule Id="S1118" Action="None" />
     <!-- Don't call GC.Collect - required for weak reference and disposal tests. -->
     <Rule Id="S1215" Action="None" />

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -39,6 +39,8 @@
     <!-- Call ConfigureAwait - shouldn't in test libraries; XUnit has opposing analyzer. -->
     <Rule Id="CA2007" Action="None" />
     <!-- Implement serialization constructors - false positive in .NET Core. -->
+    <!-- Do not raise reserved exception types - tests use generic exceptions for simulation. -->
+    <Rule Id="CA2201" Action="None" />
     <Rule Id="CA2229" Action="None" />
     <!-- Use Uri instead of string parameters - strings are easier for testing. -->
     <Rule Id="CA2234" Action="None" />

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -6,6 +6,8 @@
     <Rule Id="CA1031" Action="None" />
     <!-- Avoid empty interfaces - happens a lot in unit tests for service resolution. -->
     <Rule Id="CA1040" Action="None" />
+    <!-- Implement IDisposable correctly (must be explicitly enabled). -->
+    <Rule Id="CA1063" Action="Warning" />
     <!-- Do not pass literals as localized parameters - tests don't need to localize. -->
     <Rule Id="CA1303" Action="None" />
     <!-- Avoid excessive inheritance (must be explicitly enabled). -->
@@ -54,9 +56,9 @@
     <Rule Id="S1118" Action="None" />
     <!-- Don't call GC.Collect - required for weak reference and disposal tests. -->
     <Rule Id="S1215" Action="None" />
-    <!-- Remove unused private members - reflection tests need non-public members. -->
     <!-- Do not use obsolete members - tests exercise deprecated APIs to verify backward compat. -->
     <Rule Id="S1133" Action="None" />
+    <!-- Remove unused private members - reflection tests need non-public members. -->
     <Rule Id="S1144" Action="None" />
     <!-- Empty method bodies - test stubs often have no-op implementations. -->
     <Rule Id="S1186" Action="None" />
@@ -80,6 +82,8 @@
     <Rule Id="S2335" Action="None" />
     <!-- Cognitive complexity (must be explicitly enabled). -->
     <Rule Id="S3776" Action="Warning" />
+    <!-- IDisposable pattern - test dispose implementations are intentionally simplified. -->
+    <Rule Id="S3881" Action="None" />
     <!-- Split method for params check + iterator - overly prescriptive for our patterns. -->
     <Rule Id="S4456" Action="None" />
     <!-- Don't use Thread.Sleep - required for concurrency and timing tests. -->

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -1,16 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="16.0">
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac test assemblies." ToolsVersion="16.0">
   <IncludeAll Action="Warning" />
-  <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
-    <!-- Avoid excessive parameters on generic types (must be explicitly enabled). -->
-    <Rule Id="CA1005" Action="Warning" />
-    <!-- Don't catch general exceptions - test scenarios sometimes require general exception handling. -->
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.Analyzers" RuleNamespace="Microsoft.CodeAnalysis.Analyzers">
+    <!-- Don't catch general exceptions - test scenarios sometimes require it. -->
     <Rule Id="CA1031" Action="None" />
-    <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
-    <Rule Id="CA1032" Action="None" />
-    <!-- Avoid empty interfaces - in unit tests for service resolution, this happens a lot. -->
+    <!-- Avoid empty interfaces - happens a lot in unit tests for service resolution. -->
     <Rule Id="CA1040" Action="None" />
-    <!-- Do not pass literals as localized parameters  - tests don't need to localize. -->
+    <!-- Do not pass literals as localized parameters - tests don't need to localize. -->
     <Rule Id="CA1303" Action="None" />
     <!-- Avoid excessive inheritance (must be explicitly enabled). -->
     <Rule Id="CA1501" Action="Warning" />
@@ -20,34 +16,64 @@
     <Rule Id="CA1505" Action="Warning" />
     <!-- Avoid excessive class coupling (must be explicitly enabled). -->
     <Rule Id="CA1506" Action="Warning" />
-    <!-- Use ArgumentNullException.ThrowIfNull - this isn't available until we stop targeting netstandard. -->
-    <Rule Id="CA1510" Action="None" />
-    <!-- Make API types internal - causes problems with tests and test assemblies. -->
+    <!-- Make API types internal - causes problems with tests. -->
     <Rule Id="CA1515" Action="None" />
-    <!-- Remove the underscores from member name - unit test scenarios may use underscores. -->
+    <!-- Remove underscores from member name - test naming conventions use underscore. -->
     <Rule Id="CA1707" Action="None" />
-    <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
-    <Rule Id="CA1716" Action="None" />
-    <!-- Internal class that appears to never be instantiated - lots of false positives here because they're test stubs created by Autofac registrations. -->
+    <!-- Internal class that appears to never be instantiated - false positives from DI. -->
     <Rule Id="CA1812" Action="None" />
-    <!-- Change Dispose() to call GC.SuppressFinalize - in tests we don't really care and it can impact readability. -->
+    <!-- Change Dispose() to call GC.SuppressFinalize - unimportant in tests. -->
     <Rule Id="CA1816" Action="None" />
-    <!-- Mark members static - test methods may not access member data but also can't be static. -->
+    <!-- Mark members static - test methods may not access member data. -->
     <Rule Id="CA1822" Action="None" />
-    <!-- Seal internal types for performance - in tests we don't really care and it gets painful to enforce. -->
+    <!-- Use the LoggerMessage delegates - noise in tests, performance irrelevant. -->
+    <Rule Id="CA1848" Action="None" />
+    <!-- Seal internal types - unimportant in tests. -->
     <Rule Id="CA1852" Action="None" />
-    <!-- Prefer static readonly fields over constant array arguments - constant array arguments happen a lot in unit tests for assertions and test setup. -->
+    <!-- Prefer static readonly fields over constant arrays - happens in test setup. -->
     <Rule Id="CA1861" Action="None" />
-    <!-- Cache a CompositeFormat object for use in String.Format - this makes unit tests harder to read, and performance isn't an issue. -->
+    <!-- Cache a CompositeFormat - makes tests harder to read. -->
     <Rule Id="CA1863" Action="None" />
-    <!-- Call ConfigureAwait on tasks - you shouldn't do this in unit test libraries; XUnit has an opposite analyzer. -->
+    <!-- Call ConfigureAwait - shouldn't in test libraries; XUnit has opposing analyzer. -->
     <Rule Id="CA2007" Action="None" />
-    <!-- Implement serialization constructors - false positive when building .NET Core. -->
+    <!-- Implement serialization constructors - false positive in .NET Core. -->
     <Rule Id="CA2229" Action="None" />
     <!-- Use Uri instead of string parameters - strings are easier for testing. -->
     <Rule Id="CA2234" Action="None" />
-    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
+    <!-- Mark ISerializable types with SerializableAttribute - false positive in .NET Core. -->
     <Rule Id="CA2237" Action="None" />
+    <!-- Prefer generic overloads - reflection work in Autofac needs to be tested. -->
+    <Rule Id="CA2263" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
+    <!-- Don't use hardcoded paths or URIs - needed in several test cases. -->
+    <Rule Id="S1075" Action="None" />
+    <!-- Remove unused private members - reflection tests need non-public members. -->
+    <Rule Id="S1144" Action="None" />
+    <!-- Empty method bodies - test stubs often have no-op implementations. -->
+    <Rule Id="S1186" Action="None" />
+    <!-- Remove unused method parameters - reflection tests declare parameters not used in the body. -->
+    <Rule Id="S1172" Action="None" />
+    <!-- Remove empty class - test stubs for DI resolution don't need implementation. -->
+    <Rule Id="S2094" Action="None" />
+    <!-- Make member static - test fixture members may not access instance data. -->
+    <Rule Id="S2325" Action="None" />
+    <!-- Remove unused type parameters - used in reflection testing. -->
+    <Rule Id="S2326" Action="None" />
+    <!-- Write-only properties - reflection tests verify property setter behavior. -->
+    <Rule Id="S2376" Action="None" />
+    <!-- Classes with only private constructors - reflection tests verify inaccessible constructors. -->
+    <Rule Id="S3453" Action="None" />
+    <!-- Remove unassigned auto-property - reflection tests verify non-public property behavior. -->
+    <Rule Id="S3459" Action="None" />
+    <!-- Complete the TODO - acceptable in tests for backlog items. -->
+    <Rule Id="S1135" Action="None" />
+    <!-- Make instance property static - false positives in data/document types. -->
+    <Rule Id="S2335" Action="None" />
+    <!-- Cognitive complexity (must be explicitly enabled). -->
+    <Rule Id="S3776" Action="Warning" />
+    <!-- Set route attributes at top of controller - false positive. -->
+    <Rule Id="S6934" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <!-- Prefix local calls with this. -->
@@ -56,11 +82,11 @@
     <Rule Id="SA1121" Action="None" />
     <!-- Use String.Empty instead of "". -->
     <Rule Id="SA1122" Action="None" />
-    <!-- Enforce order of class members by member type - sometimes putting test classes/data by the test helps. -->
+    <!-- Enforce order of class members by member type. -->
     <Rule Id="SA1201" Action="None" />
-    <!-- Enforce order of class members by member visibility - sometimes putting test classes/data by the test helps. -->
+    <!-- Enforce order of class members by visibility. -->
     <Rule Id="SA1202" Action="None" />
-    <!-- Enforce order of static vs. non-static members - sometimes putting test classes/data by the test helps. -->
+    <!-- Enforce order of static vs. non-static members. -->
     <Rule Id="SA1204" Action="None" />
     <!-- Fields can't start with underscore. -->
     <Rule Id="SA1309" Action="None" />
@@ -80,6 +106,13 @@
     <Rule Id="SA1618" Action="None" />
     <!-- Don't copy/paste documentation. -->
     <Rule Id="SA1625" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="xUnit" RuleNamespace="xUnit">
+    <!-- Use Assert.Single when there's only one collection entry. -->
+    <Rule Id="xUnit2023" Action="Warning" />
+  </Rules>
+  <!-- IDE rules for test assemblies. -->
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
     <!-- Private member is unused - tests for reflection require members that may not get used. -->
     <Rule Id="IDE0051" Action="None" />
     <!-- Private member assigned value never read - tests for reflection require values that may not get used. -->

--- a/src/Autofac.Extensions.DependencyInjection/Autofac.Extensions.DependencyInjection.csproj
+++ b/src/Autofac.Extensions.DependencyInjection/Autofac.Extensions.DependencyInjection.csproj
@@ -57,6 +57,10 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Autofac.Extensions.DependencyInjection/AutofacRegistration.cs
+++ b/src/Autofac.Extensions.DependencyInjection/AutofacRegistration.cs
@@ -283,7 +283,6 @@ public static class AutofacRegistration
 
                     var serviceProvider = context.Resolve<IServiceProvider>();
 
-                    var keyedService = (Autofac.Core.KeyedService)requestContext.Service;
                     var key = requestContext.Parameters.KeyedServiceKey<object>();
 
                     return descriptor.KeyedImplementationFactory(serviceProvider, key);

--- a/src/Autofac.Extensions.DependencyInjection/AutofacServiceProvider.cs
+++ b/src/Autofac.Extensions.DependencyInjection/AutofacServiceProvider.cs
@@ -12,7 +12,7 @@ namespace Autofac.Extensions.DependencyInjection;
 /// </summary>
 /// <seealso cref="IServiceProvider" />
 /// <seealso cref="ISupportRequiredService" />
-public class AutofacServiceProvider : IServiceProvider, ISupportRequiredService, IKeyedServiceProvider, IServiceProviderIsService, IServiceProviderIsKeyedService, IDisposable, IAsyncDisposable
+public class AutofacServiceProvider : ISupportRequiredService, IKeyedServiceProvider, IServiceProviderIsKeyedService, IDisposable, IAsyncDisposable
 {
     private readonly ILifetimeScope _lifetimeScope;
 

--- a/src/Autofac.Extensions.DependencyInjection/FromKeyedServicesUsageCache.cs
+++ b/src/Autofac.Extensions.DependencyInjection/FromKeyedServicesUsageCache.cs
@@ -145,16 +145,16 @@ internal static class FromKeyedServicesUsageCache
             _cache.Clear();
         }
 
-        public void Clear(ReflectionCacheClearPredicate clearPredicate)
+        public void Clear(ReflectionCacheClearPredicate predicate)
         {
-            if (clearPredicate is null)
+            if (predicate is null)
             {
-                throw new ArgumentNullException(nameof(clearPredicate));
+                throw new ArgumentNullException(nameof(predicate));
             }
 
             foreach (var key in _cache.Keys)
             {
-                if (key.Matches(clearPredicate))
+                if (key.Matches(predicate))
                 {
                     _cache.TryRemove(key, out _);
                 }

--- a/src/Autofac.Extensions.DependencyInjection/FromKeyedServicesUsageCache.cs
+++ b/src/Autofac.Extensions.DependencyInjection/FromKeyedServicesUsageCache.cs
@@ -121,16 +121,19 @@ internal static class FromKeyedServicesUsageCache
 
         public ReflectionCacheUsage Usage => ReflectionCacheUsage.Registration;
 
+        [SuppressMessage("S1144", "S1144", Justification = "Method is required for IReflectionCache but not used by this implementation.")]
         public bool TryGet(CacheKey key, out bool result)
         {
             return _cache.TryGetValue(key, out result);
         }
 
+        [SuppressMessage("S1144", "S1144", Justification = "Method is required for IReflectionCache but not used by this implementation.")]
         public bool GetOrAdd(CacheKey key, bool value)
         {
             return _cache.GetOrAdd(key, value);
         }
 
+        [SuppressMessage("S1144", "S1144", Justification = "Method is required for IReflectionCache but not used by this implementation.")]
         public bool GetOrAdd(CacheKey key, Func<CacheKey, (IConstructorFinder ConstructorFinder, Type LimitType), bool> valueFactory, (IConstructorFinder ConstructorFinder, Type LimitType) state)
         {
 #if NETSTANDARD2_0

--- a/src/Autofac.Extensions.DependencyInjection/KeyTypeManipulation.cs
+++ b/src/Autofac.Extensions.DependencyInjection/KeyTypeManipulation.cs
@@ -254,18 +254,18 @@ internal class KeyTypeManipulation
             _defaultValueCache.Clear();
         }
 
-        public void Clear(ReflectionCacheClearPredicate clearPredicate)
+        public void Clear(ReflectionCacheClearPredicate predicate)
         {
-            if (clearPredicate is null)
+            if (predicate is null)
             {
-                throw new ArgumentNullException(nameof(clearPredicate));
+                throw new ArgumentNullException(nameof(predicate));
             }
 
             foreach (var parameter in _parameterConverterAttributes.Keys)
             {
                 var member = parameter.Member;
                 var assemblies = GetParameterAssemblies(parameter);
-                if (clearPredicate(member, assemblies))
+                if (predicate(member, assemblies))
                 {
                     _parameterConverterAttributes.TryRemove(parameter, out _);
                 }
@@ -273,7 +273,7 @@ internal class KeyTypeManipulation
 
             foreach (var member in _memberConverterAttributes.Keys)
             {
-                if (clearPredicate(member, new[] { member.Module.Assembly }))
+                if (predicate(member, new[] { member.Module.Assembly }))
                 {
                     _memberConverterAttributes.TryRemove(member, out _);
                 }
@@ -281,7 +281,7 @@ internal class KeyTypeManipulation
 
             foreach (var type in _tryParseMethodCache.Keys)
             {
-                if (clearPredicate(type, new[] { type.Assembly }))
+                if (predicate(type, new[] { type.Assembly }))
                 {
                     _tryParseMethodCache.TryRemove(type, out _);
                 }
@@ -289,7 +289,7 @@ internal class KeyTypeManipulation
 
             foreach (var type in _defaultValueCache.Keys)
             {
-                if (clearPredicate(type, new[] { type.Assembly }))
+                if (predicate(type, new[] { type.Assembly }))
                 {
                     _defaultValueCache.TryRemove(type, out _);
                 }
@@ -297,7 +297,7 @@ internal class KeyTypeManipulation
 
             foreach (var entry in _converterTypeCache)
             {
-                if (clearPredicate(entry.Value, new[] { entry.Value.Assembly }))
+                if (predicate(entry.Value, new[] { entry.Value.Assembly }))
                 {
                     _converterTypeCache.TryRemove(entry.Key, out _);
                 }

--- a/src/Autofac.Extensions.DependencyInjection/KeyTypeManipulation.cs
+++ b/src/Autofac.Extensions.DependencyInjection/KeyTypeManipulation.cs
@@ -111,28 +111,14 @@ internal class KeyTypeManipulation
             return value;
         }
 
-        TypeConverter converter;
-
         // Try to get custom type converter information.
-        if (converterAttribute != null && !string.IsNullOrEmpty(converterAttribute.ConverterTypeName))
+        if (TryConvertWithAttribute(value, destinationType, converterAttribute, out var attributeResult))
         {
-            try
-            {
-                converter = GetTypeConverterFromName(converterAttribute.ConverterTypeName);
-            }
-            catch (InvalidOperationException ex)
-            {
-                throw new KeyTypeConversionException(value.GetType(), destinationType, ex);
-            }
-
-            if (converter.CanConvertFrom(value.GetType()))
-            {
-                return converter.ConvertFrom(null, CultureInfo.InvariantCulture, value);
-            }
+            return attributeResult;
         }
 
         // If there's not a custom converter specified via attribute, try for a default.
-        converter = TypeDescriptor.GetConverter(value.GetType());
+        var converter = TypeDescriptor.GetConverter(value.GetType());
         if (converter.CanConvertTo(destinationType))
         {
             return converter.ConvertTo(null, CultureInfo.InvariantCulture, value, destinationType);
@@ -162,6 +148,34 @@ internal class KeyTypeManipulation
         }
 
         throw new KeyTypeConversionException(value.GetType(), destinationType);
+    }
+
+    private static bool TryConvertWithAttribute(object value, Type destinationType, TypeConverterAttribute? converterAttribute, out object? converted)
+    {
+        converted = null;
+
+        if (converterAttribute == null || string.IsNullOrEmpty(converterAttribute.ConverterTypeName))
+        {
+            return false;
+        }
+
+        TypeConverter converter;
+        try
+        {
+            converter = GetTypeConverterFromName(converterAttribute.ConverterTypeName);
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw new KeyTypeConversionException(value.GetType(), destinationType, ex);
+        }
+
+        if (!converter.CanConvertFrom(value.GetType()))
+        {
+            return false;
+        }
+
+        converted = converter.ConvertFrom(null, CultureInfo.InvariantCulture, value);
+        return true;
     }
 
     /// <summary>
@@ -261,47 +275,11 @@ internal class KeyTypeManipulation
                 throw new ArgumentNullException(nameof(predicate));
             }
 
-            foreach (var parameter in _parameterConverterAttributes.Keys)
-            {
-                var member = parameter.Member;
-                var assemblies = GetParameterAssemblies(parameter);
-                if (predicate(member, assemblies))
-                {
-                    _parameterConverterAttributes.TryRemove(parameter, out _);
-                }
-            }
-
-            foreach (var member in _memberConverterAttributes.Keys)
-            {
-                if (predicate(member, new[] { member.Module.Assembly }))
-                {
-                    _memberConverterAttributes.TryRemove(member, out _);
-                }
-            }
-
-            foreach (var type in _tryParseMethodCache.Keys)
-            {
-                if (predicate(type, new[] { type.Assembly }))
-                {
-                    _tryParseMethodCache.TryRemove(type, out _);
-                }
-            }
-
-            foreach (var type in _defaultValueCache.Keys)
-            {
-                if (predicate(type, new[] { type.Assembly }))
-                {
-                    _defaultValueCache.TryRemove(type, out _);
-                }
-            }
-
-            foreach (var entry in _converterTypeCache)
-            {
-                if (predicate(entry.Value, new[] { entry.Value.Assembly }))
-                {
-                    _converterTypeCache.TryRemove(entry.Key, out _);
-                }
-            }
+            ClearParameterConverterAttributes(predicate);
+            ClearMemberConverterAttributes(predicate);
+            ClearTryParseMethodCache(predicate);
+            ClearDefaultValueCache(predicate);
+            ClearConverterTypeCache(predicate);
         }
 
         private static IEnumerable<Assembly> GetParameterAssemblies(ParameterInfo parameter)
@@ -317,6 +295,63 @@ internal class KeyTypeManipulation
 
             yield return memberAssembly;
             yield return parameterAssembly;
+        }
+
+        private void ClearParameterConverterAttributes(ReflectionCacheClearPredicate predicate)
+        {
+            foreach (var parameter in _parameterConverterAttributes.Keys)
+            {
+                var member = parameter.Member;
+                var assemblies = GetParameterAssemblies(parameter);
+                if (predicate(member, assemblies))
+                {
+                    _parameterConverterAttributes.TryRemove(parameter, out _);
+                }
+            }
+        }
+
+        private void ClearMemberConverterAttributes(ReflectionCacheClearPredicate predicate)
+        {
+            foreach (var member in _memberConverterAttributes.Keys)
+            {
+                if (predicate(member, new[] { member.Module.Assembly }))
+                {
+                    _memberConverterAttributes.TryRemove(member, out _);
+                }
+            }
+        }
+
+        private void ClearTryParseMethodCache(ReflectionCacheClearPredicate predicate)
+        {
+            foreach (var type in _tryParseMethodCache.Keys)
+            {
+                if (predicate(type, new[] { type.Assembly }))
+                {
+                    _tryParseMethodCache.TryRemove(type, out _);
+                }
+            }
+        }
+
+        private void ClearDefaultValueCache(ReflectionCacheClearPredicate predicate)
+        {
+            foreach (var type in _defaultValueCache.Keys)
+            {
+                if (predicate(type, new[] { type.Assembly }))
+                {
+                    _defaultValueCache.TryRemove(type, out _);
+                }
+            }
+        }
+
+        private void ClearConverterTypeCache(ReflectionCacheClearPredicate predicate)
+        {
+            foreach (var entry in _converterTypeCache)
+            {
+                if (predicate(entry.Value, new[] { entry.Value.Assembly }))
+                {
+                    _converterTypeCache.TryRemove(entry.Key, out _);
+                }
+            }
         }
     }
 }

--- a/src/Autofac.Extensions.DependencyInjection/KeyedServiceMiddleware.cs
+++ b/src/Autofac.Extensions.DependencyInjection/KeyedServiceMiddleware.cs
@@ -168,16 +168,16 @@ internal class KeyedServiceMiddleware : IResolveMiddleware
                 _fromKeyedServicesAttributes.Clear();
             }
 
-            public void Clear(ReflectionCacheClearPredicate clearPredicate)
+            public void Clear(ReflectionCacheClearPredicate predicate)
             {
-                if (clearPredicate is null)
+                if (predicate is null)
                 {
-                    throw new ArgumentNullException(nameof(clearPredicate));
+                    throw new ArgumentNullException(nameof(predicate));
                 }
 
                 foreach (var parameter in _microsoftServiceKeyAttributePresence.Keys)
                 {
-                    if (Matches(clearPredicate, parameter))
+                    if (Matches(predicate, parameter))
                     {
                         _microsoftServiceKeyAttributePresence.TryRemove(parameter, out _);
                     }
@@ -185,7 +185,7 @@ internal class KeyedServiceMiddleware : IResolveMiddleware
 
                 foreach (var parameter in _fromKeyedServicesAttributes.Keys)
                 {
-                    if (Matches(clearPredicate, parameter))
+                    if (Matches(predicate, parameter))
                     {
                         _fromKeyedServicesAttributes.TryRemove(parameter, out _);
                     }

--- a/src/Autofac.Extensions.DependencyInjection/TypeExtensions.cs
+++ b/src/Autofac.Extensions.DependencyInjection/TypeExtensions.cs
@@ -77,16 +77,16 @@ internal static class TypeExtensions
             _collectionTypeCache.Clear();
         }
 
-        public void Clear(ReflectionCacheClearPredicate clearPredicate)
+        public void Clear(ReflectionCacheClearPredicate predicate)
         {
-            if (clearPredicate is null)
+            if (predicate is null)
             {
-                throw new ArgumentNullException(nameof(clearPredicate));
+                throw new ArgumentNullException(nameof(predicate));
             }
 
             foreach (var type in _collectionTypeCache.Keys)
             {
-                if (clearPredicate(type, new[] { type.Assembly }))
+                if (predicate(type, new[] { type.Assembly }))
                 {
                     _collectionTypeCache.TryRemove(type, out _);
                 }

--- a/test/Autofac.Extensions.DependencyInjection.Integration.Test/Autofac.Extensions.DependencyInjection.Integration.Test.csproj
+++ b/test/Autofac.Extensions.DependencyInjection.Integration.Test/Autofac.Extensions.DependencyInjection.Integration.Test.csproj
@@ -34,6 +34,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Autofac.Extensions.DependencyInjection.Integration.Test/IntegrationTests.cs
+++ b/test/Autofac.Extensions.DependencyInjection.Integration.Test/IntegrationTests.cs
@@ -27,6 +27,7 @@ public class IntegrationTests : IClassFixture<WebApplicationFactory<Startup>>
     {
         var client = AppFactory.CreateClient();
         var response = await client.GetAsync(new Uri("/Date", UriKind.Relative));
-        response.EnsureSuccessStatusCode();
+        var exception = Record.Exception(() => response.EnsureSuccessStatusCode());
+        Assert.Null(exception);
     }
 }

--- a/test/Autofac.Extensions.DependencyInjection.Test/Autofac.Extensions.DependencyInjection.Test.csproj
+++ b/test/Autofac.Extensions.DependencyInjection.Test/Autofac.Extensions.DependencyInjection.Test.csproj
@@ -31,6 +31,10 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Autofac.Extensions.DependencyInjection.Test/AutofacChildLifetimeScopeServiceProviderFactoryTests.cs
+++ b/test/Autofac.Extensions.DependencyInjection.Test/AutofacChildLifetimeScopeServiceProviderFactoryTests.cs
@@ -38,7 +38,7 @@ public sealed class AutofacChildLifetimeScopeServiceProviderFactoryTests
     [Fact]
     public void CreateBuilderAllowsForNullConfigurationAction()
     {
-        var factory = new AutofacChildLifetimeScopeServiceProviderFactory(GetRootLifetimeScope);
+        var factory = new AutofacChildLifetimeScopeServiceProviderFactory(GetRootLifetimeScope, null);
 
         var configurationAdapter = factory.CreateBuilder(new ServiceCollection());
 

--- a/test/Autofac.Extensions.DependencyInjection.Test/AutofacChildLifetimeScopeServiceProviderFactoryTests.cs
+++ b/test/Autofac.Extensions.DependencyInjection.Test/AutofacChildLifetimeScopeServiceProviderFactoryTests.cs
@@ -108,8 +108,12 @@ public sealed class AutofacChildLifetimeScopeServiceProviderFactoryTests
 
         var serviceProvider = factory.CreateServiceProvider(configurationAdapter);
 
-        serviceProvider.GetRequiredService<DependencyOne>();
-        serviceProvider.GetRequiredService<DependencyTwo>();
+        var exception = Record.Exception(() =>
+        {
+            serviceProvider.GetRequiredService<DependencyOne>();
+            serviceProvider.GetRequiredService<DependencyTwo>();
+        });
+        Assert.Null(exception);
     }
 
     [Fact]
@@ -121,7 +125,8 @@ public sealed class AutofacChildLifetimeScopeServiceProviderFactoryTests
 
         var serviceProvider = factory.CreateServiceProvider(configurationAdapter);
 
-        serviceProvider.GetRequiredService<DependencyOne>();
+        var exception = Record.Exception(() => serviceProvider.GetRequiredService<DependencyOne>());
+        Assert.Null(exception);
     }
 
     [Fact]

--- a/test/Autofac.Extensions.DependencyInjection.Test/AutofacServiceProviderFactoryTests.cs
+++ b/test/Autofac.Extensions.DependencyInjection.Test/AutofacServiceProviderFactoryTests.cs
@@ -31,7 +31,7 @@ public class AutofacServiceProviderFactoryTests
     [Fact]
     public void CreateBuilderAllowsForNullConfigurationAction()
     {
-        var factory = new AutofacServiceProviderFactory();
+        var factory = new AutofacServiceProviderFactory(null);
 
         var builder = factory.CreateBuilder(new ServiceCollection());
 

--- a/test/Autofac.Extensions.DependencyInjection.Test/KeyTypeManipulationFixture.cs
+++ b/test/Autofac.Extensions.DependencyInjection.Test/KeyTypeManipulationFixture.cs
@@ -107,7 +107,7 @@ public class KeyTypeManipulationFixture
     public void ChangeToCompatibleTypeUsesTypeConverterOnParameter()
     {
         var ctor = typeof(HasTypeConverterAttributes).GetConstructor(new Type[] { typeof(Convertible) });
-        var member = ctor.GetParameters().First();
+        var member = ctor.GetParameters()[0];
         var actual = KeyTypeManipulation.ChangeToCompatibleType("25", typeof(Convertible), member) as Convertible;
         Assert.NotNull(actual);
         Assert.Equal(25, actual.Value);

--- a/test/Autofac.Extensions.DependencyInjection.Test/Specification/AssumedBehaviorTests.cs
+++ b/test/Autofac.Extensions.DependencyInjection.Test/Specification/AssumedBehaviorTests.cs
@@ -163,7 +163,7 @@ public abstract class AssumedBehaviorTests
         var rootProvider = CreateServiceProvider(services);
 
         var outerScope = rootProvider.CreateScope();
-        var innerScope = outerScope.ServiceProvider.CreateScope();
+        using var innerScope = outerScope.ServiceProvider.CreateScope();
         outerScope.Dispose();
 
         // This part will blow up if the scopes are hierarchical.

--- a/test/Autofac.Extensions.DependencyInjection.Test/Specification/AssumedBehaviorTests.cs
+++ b/test/Autofac.Extensions.DependencyInjection.Test/Specification/AssumedBehaviorTests.cs
@@ -167,8 +167,12 @@ public abstract class AssumedBehaviorTests
         outerScope.Dispose();
 
         // This part will blow up if the scopes are hierarchical.
-        innerScope.ServiceProvider.GetRequiredService<DisposeTracker>();
-        innerScope.Dispose();
+        var exception = Record.Exception(() =>
+        {
+            innerScope.ServiceProvider.GetRequiredService<DisposeTracker>();
+            innerScope.Dispose();
+        });
+        Assert.Null(exception);
     }
 
     [Fact]

--- a/test/Integration.Net10/Integration.Net10.csproj
+++ b/test/Integration.Net10/Integration.Net10.csproj
@@ -18,6 +18,10 @@
     <ProjectReference Include="..\..\src\Autofac.Extensions.DependencyInjection\Autofac.Extensions.DependencyInjection.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Integration.Net8/Integration.Net8.csproj
+++ b/test/Integration.Net8/Integration.Net8.csproj
@@ -18,6 +18,10 @@
     <ProjectReference Include="..\..\src\Autofac.Extensions.DependencyInjection\Autofac.Extensions.DependencyInjection.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary

- Adds SonarAnalyzer.CSharp (10.27.0.140913) to all projects
- Introduces unified `build/Source.ruleset` and `build/Test.ruleset` with consistent analyzer configuration
- Fixes all actionable analyzer warnings (code changes per-rule in individual commits)
- Disables rules that are false positives or inapplicable for this project's patterns

## Changes

- **New analyzer**: SonarAnalyzer.CSharp added via PackageReference with PrivateAssets=all
- **Rulesets**: Unified Source.ruleset and Test.ruleset covering Microsoft, Sonar, StyleCop, and xUnit analyzers
- **Code fixes**: Various warning fixes committed individually by rule ID for easy review
- **Zero warnings**: Build completes with no analyzer warnings

## Test plan

- [ ] CI build passes (zero errors, zero warnings)
- [ ] All existing tests pass
- [ ] No public API changes (verify with `dotnet format --verify-no-changes`)