### PR TITLE
Update dependencies (Autofac 9.3.1)

### DIFF
--- a/bench/Autofac.Extensions.DependencyInjection.Bench/Autofac.Extensions.DependencyInjection.Bench.csproj
+++ b/bench/Autofac.Extensions.DependencyInjection.Bench/Autofac.Extensions.DependencyInjection.Bench.csproj
@@ -33,8 +33,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.28.0.143324">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/default.proj
+++ b/default.proj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="All" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
   <PropertyGroup>
     <!-- Increment the overall semantic version here. -->
-    <Version>11.0.1</Version>
+    <Version>11.0.2</Version>
     <SolutionName>Autofac.Extensions.DependencyInjection</SolutionName>
     <Configuration Condition="'$(Configuration)'==''">Release</Configuration>
     <ArtifactDirectory>$([System.IO.Path]::Combine($(MSBuildProjectDirectory),"artifacts"))</ArtifactDirectory>

--- a/src/Autofac.Extensions.DependencyInjection/Autofac.Extensions.DependencyInjection.csproj
+++ b/src/Autofac.Extensions.DependencyInjection/Autofac.Extensions.DependencyInjection.csproj
@@ -53,12 +53,12 @@
     <AdditionalFiles Include="..\..\build\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="9.2.0" />
+    <PackageReference Include="Autofac" Version="9.3.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.28.0.143324">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Autofac.Extensions.DependencyInjection.Integration.Test/Autofac.Extensions.DependencyInjection.Integration.Test.csproj
+++ b/test/Autofac.Extensions.DependencyInjection.Integration.Test/Autofac.Extensions.DependencyInjection.Integration.Test.csproj
@@ -36,8 +36,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.28.0.143324">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Autofac.Extensions.DependencyInjection.Test/Autofac.Extensions.DependencyInjection.Test.csproj
+++ b/test/Autofac.Extensions.DependencyInjection.Test/Autofac.Extensions.DependencyInjection.Test.csproj
@@ -31,8 +31,8 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.28.0.143324">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Integration.Net10/Integration.Net10.csproj
+++ b/test/Integration.Net10/Integration.Net10.csproj
@@ -18,7 +18,7 @@
     <ProjectReference Include="..\..\src\Autofac.Extensions.DependencyInjection\Autofac.Extensions.DependencyInjection.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.28.0.143324">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Integration.Net8/Integration.Net8.csproj
+++ b/test/Integration.Net8/Integration.Net8.csproj
@@ -18,7 +18,7 @@
     <ProjectReference Include="..\..\src\Autofac.Extensions.DependencyInjection\Autofac.Extensions.DependencyInjection.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.28.0.143324">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

- Updates Autofac from 9.2.0 to 9.3.1 (src shipping package)
- Updates SonarAnalyzer.CSharp from 10.27.0.140913 to 10.28.0.143324 (src + all test/bench projects; analyzer-only, private assets)
- Updates Microsoft.NET.Test.Sdk from 18.6.0 to 18.7.0 (test + bench projects; test-only)
- Bumps package version 11.0.1 -> 11.0.2

## Dependency categories

- **Autofac (src/shipping):** 9.2.0 -> 9.3.1
- **SonarAnalyzer.CSharp (analyzer, private assets):** 10.27.0.140913 -> 10.28.0.143324 — affects src build tooling but not shipped output
- **Microsoft.NET.Test.Sdk (test-only):** 18.6.0 -> 18.7.0

## Test plan

- [ ] CI build passes (compile + test on net8.0 and net10.0)
- [ ] No new warnings or analyzer violations